### PR TITLE
Feature/undo

### DIFF
--- a/src/Neon.js
+++ b/src/Neon.js
@@ -10,6 +10,9 @@ export default function Neon (mei, vrvToolkit) {
         pageMarginTop: 0,
         font: "Bravura",
     };
+    var undoStack = new Array(0);
+    var redoStack = new Array(0);
+
     vrvToolkit.setOptions(vrvOptions);
     loadData(mei);
 
@@ -30,11 +33,37 @@ export default function Neon (mei, vrvToolkit) {
     }
 
     function edit (editorAction) {
-        return vrvToolkit.edit(editorAction);
+        let currentMEI = getMEI();
+        let value = vrvToolkit.edit(editorAction);
+        if (value) {
+            undoStack.push(currentMEI);
+            redoStack = new Array(0);
+        }
+        return value; 
     }
 
     function info () {
         return vrvToolkit.editInfo();
+    }
+
+    function undo () {
+        let state = undoStack.pop();
+        if (state !== undefined) {
+            redoStack.push(getMEI());
+            loadData(state);
+            return true;
+        }
+        return false;
+    }
+
+    function redo () {
+        let state = redoStack.pop();
+        if (state !== undefined) {
+            undoStack.push(getMEI());
+            loadData(state);
+            return true;
+        }
+        return false;
     }
 
     // Constructor reference
@@ -45,4 +74,6 @@ export default function Neon (mei, vrvToolkit) {
     Neon.prototype.getElementAttr = getElementAttr;
     Neon.prototype.edit = edit;
     Neon.prototype.info = info;
+    Neon.prototype.undo = undo;
+    Neon.prototype.redo = redo;
 }

--- a/test/Neon.test.js
+++ b/test/Neon.test.js
@@ -112,3 +112,31 @@ test("Test 'remove' action", () => {
     let atts = neon.getElementAttr("m-ceab54b1-893e-42de-8fca-aeeb13254e19");
     expect(atts).toStrictEqual({});
 });
+
+test("Test undo and redo", () => {
+    let neon = new Neon(mei, new verovio.toolkit());
+    let firstSVG = neon.getSVG();
+    //Should not be able to undo or redo now
+    expect(neon.undo()).toBeFalsy();
+    expect(neon.redo()).toBeFalsy();
+    
+    let editorAction = {
+        "action": "drag",
+        "param": {
+            "elementId": "m-54220197-ac7d-452c-8c34-b3d0bdbaefa0",
+            "x": 2,
+            "y": 69 
+        }
+    };
+    // Ensure the editor is working
+    expect(neon.getElementAttr("m-5ba56425-5c59-4f34-9e56-b86779cb4d6d")).toEqual({pname: "a", oct: "2"});
+    expect(neon.edit(editorAction)).toBeTruthy();
+    expect(neon.getElementAttr("m-5ba56425-5c59-4f34-9e56-b86779cb4d6d")).toEqual({pname: "c", oct: "3"});
+
+    expect(neon.undo()).toBeTruthy();
+    neon.getSVG();
+    expect(neon.getElementAttr("m-5ba56425-5c59-4f34-9e56-b86779cb4d6d")).toEqual({pname: "a", oct: "2"});
+    expect(neon.redo()).toBeTruthy();
+    neon.getSVG();
+    expect(neon.getElementAttr("m-5ba56425-5c59-4f34-9e56-b86779cb4d6d")).toEqual({pname: "c", oct: "3"});
+});

--- a/test/Neon.test.js
+++ b/test/Neon.test.js
@@ -98,3 +98,17 @@ describe("Test insert editor action", () => {
         expect(insertAtts.oct).toBe("2");
     });
 });
+
+test("Test 'remove' action", () => {
+    let neon = new Neon(mei, new verovio.toolkit());
+    neon.getSVG();
+    let editorAction = {
+        "action": "remove",
+        "param": {
+            "elementId": "m-ceab54b1-893e-42de-8fca-aeeb13254e19"
+        }
+    };
+    expect(neon.edit(editorAction)).toBeTruthy();
+    let atts = neon.getElementAttr("m-ceab54b1-893e-42de-8fca-aeeb13254e19");
+    expect(atts).toStrictEqual({});
+});


### PR DESCRIPTION
Changelog:

* Undo and redo in Neon (no access to it). Both are based on saving the state of the MEI from Verovio and then reloading that as necessary.
* Add unit tests for both in `test/Neon.test.js`.

Note: We should switch to undoing the action itself and not doing state-based undo/redo once the editor actions are more developed. This method will end up using more memory, especially as more actions are performed and larger files are used.