### PR TITLE
Feature/highlight staff

### DIFF
--- a/src/ColorStaves.js
+++ b/src/ColorStaves.js
@@ -1,0 +1,44 @@
+// Color staff lines and their children so it's easy to see which components belong to which staff
+
+export default class ColorStaves {
+    setColor() {
+        let staves = Array.from(document.getElementsByClassName("staff"));
+        for (var i = 0; i < staves.length; i++) {
+            let staffColor = ColorStaves.Colors[i % ColorStaves.Colors.length];
+            let children = Array.from($("#" + staves[i].id).children());
+            children.forEach(child => {
+                if (child.tagName === "path") {
+                    child.setAttribute("stroke", staffColor);
+                } else {
+                    child.setAttribute("fill", staffColor);
+                }
+                child.setAttribute("class", child.getAttribute("class") + " highlighted");
+            });
+        }
+    }
+    unsetColor() {
+        let highlighted = Array.from(document.getElementsByClassName("highlighted"));
+        highlighted.forEach(elem => {
+            if (elem.tagName === "path") {
+                elem.setAttribute("stroke", "#000000");
+            } else {
+                elem.removeAttribute("fill");
+            }
+        });
+        $(".highlighted").removeClass("highlighted");
+    }
+}
+
+// Color palette from Figure 2 (Colors optimized for color-blind
+// individuals) from "Points of view: Color blindness" by Bang Wong
+// published in Nature Methods volume 8 on 27 May 2011
+ColorStaves.Colors = [
+    "rgb(0,0,0)",
+    "rgb(230, 159, 0)",
+    "rgb(86, 180, 233)",
+    "rgb(0, 158, 115)",
+    "rgb(240, 228, 66)",
+    "rgb(0, 114, 178)",
+    "rgb(213, 94, 0)",
+    "rgb(204, 121, 167)"
+];

--- a/src/NeonView.js
+++ b/src/NeonView.js
@@ -26,9 +26,9 @@ export default function NeonView (params) {
         infoBox = new InfoBox(neon);
         viewControls = new ViewControls(zoomHandler);
         editMode = new EditMode(this, meiFile, zoomHandler);
+        loadView();
         viewControls.setSylControls();
         viewControls.setHighlightControls();
-        loadView();
     });
 
     function loadView () {

--- a/src/NeonView.js
+++ b/src/NeonView.js
@@ -26,7 +26,8 @@ export default function NeonView (params) {
         infoBox = new InfoBox(neon);
         viewControls = new ViewControls(zoomHandler);
         editMode = new EditMode(this, meiFile, zoomHandler);
-        viewControls.setSylControls(this);
+        viewControls.setSylControls();
+        viewControls.setHighlightControls();
         loadView();
     });
 
@@ -58,7 +59,6 @@ export default function NeonView (params) {
         else {
             loadSvg(); 
         }
-        setSvgText();
         resetListeners();
     }
 
@@ -83,14 +83,6 @@ export default function NeonView (params) {
                     "fileName": meiFile}
         }) 
     } 
-
-    function setSvgText () {
-        if (viewControls.shouldHideText()) {
-            $(".syl").css("visibility", "hidden");
-        } else {
-            $(".syl").css("visibility", "visible");
-        }
-    }
 
     function loadSvg() {
         var svg = neon.getSVG();

--- a/src/Select.js
+++ b/src/Select.js
@@ -2,6 +2,7 @@ export default function Select (dragHandler) {
     selectListeners();
     //Selection mode toggle
     function selectListeners() {
+        var classesToSelect = ".nc, .clef, .custos";
         $("#selByNeume").on("click", function(){
             if ($("#selByNc").hasClass("is-active")){
                 $("#selByNc").toggleClass('is-active');
@@ -17,8 +18,8 @@ export default function Select (dragHandler) {
         });
 
         //Activating selected neumes
-        $(".nc, .clef, .custos").on("mousedown", function() {
-            var isNc = !($(this).hasClass("clef") || $(this).hasClass("custos"));
+        $(classesToSelect).on("mousedown", function() {
+            var isNc= $(this).hasClass("nc");
             if ($("#selByNeume").hasClass("is-active") && isNc){
                 if(!$(this).hasClass("selected")){
                     unselect();
@@ -54,12 +55,12 @@ export default function Select (dragHandler) {
             unselect();
         })
 
-        $(".nc, .clef, .custos").on("click", function(e){
+        $(classesToSelect).on("click", function(e){
             e.stopPropagation();
         })
 
         function unselect() {
-            var els = $(".nc.selected, .clef.selected, .custos.selected");
+            var els = $(".selected");
             for (var i=0; i<els.length; i++){
                 $(els[i]).removeClass("selected").attr("fill", null);
             }

--- a/src/ViewControls.js
+++ b/src/ViewControls.js
@@ -6,6 +6,7 @@ export default function ViewControls (zoomHandler) {
     setZoomControls();
     setOpacityControls();
     setBackgroundOpacityControls();
+    setSylControls();
     setHighlightControls();
 
     function setZoomControls() {
@@ -48,13 +49,8 @@ export default function ViewControls (zoomHandler) {
     }
 
     function setSylControls() {
-        $("#displayText").click( function () {
-            if ($("#displayText").is(":checked")) {
-                $(".syl").css("visibility", "hidden");
-            } else {
-                $(".syl").css("visibility", "visible");
-            }
-        });
+        updateSylVisibility();
+        $("#displayText").click(updateSylVisibility);
     }
 
     function setOpacityFromSlider() {
@@ -63,13 +59,24 @@ export default function ViewControls (zoomHandler) {
 
 
     function setHighlightControls(view) {
-        $("#highlightStaves").click(() => {
-            if ($("#highlightStaves").is(":checked")) {
-                color.setColor();
-            } else {
-                color.unsetColor();
-            }
-        });
+        updateHighlight();
+        $("#highlightStaves").click(updateHighlight);
+    }
+
+    function updateSylVisibility() {
+        if ($("#displayText").is(":checked")) {
+            $(".syl").css("visibility", "visible");
+        } else {
+            $(".syl").css("visibility", "hidden");
+        }
+    }
+
+    function updateHighlight() {
+        if ($("#highlightStaves").is(":checked")) {
+            color.setColor();
+        } else {
+            color.unsetColor();
+        }
     }
 
     ViewControls.prototype.constructor = ViewControls;

--- a/src/ViewControls.js
+++ b/src/ViewControls.js
@@ -1,8 +1,12 @@
+import ColorStaves from "./ColorStaves.js";
+
 export default function ViewControls (zoomHandler) {
 
+    var color = new ColorStaves();
     setZoomControls();
     setOpacityControls();
     setBackgroundOpacityControls();
+    setHighlightControls();
 
     function setZoomControls() {
         $("#reset-zoom").click( function() {
@@ -43,13 +47,13 @@ export default function ViewControls (zoomHandler) {
         });
     }
 
-    function shouldHideText() {
-        return (!$("#displayText").is(":checked"));
-    }
-
-    function setSylControls(view) {
+    function setSylControls() {
         $("#displayText").click( function () {
-            view.refreshPage();
+            if ($("#displayText").is(":checked")) {
+                $(".syl").css("visibility", "hidden");
+            } else {
+                $(".syl").css("visibility", "visible");
+            }
         });
     }
 
@@ -57,11 +61,22 @@ export default function ViewControls (zoomHandler) {
         $(".definition-scale").css("opacity", $("#opacityOutput").val() / 100.0);
     };
 
+
+    function setHighlightControls(view) {
+        $("#highlightStaves").click(() => {
+            if ($("#highlightStaves").is(":checked")) {
+                color.setColor();
+            } else {
+                color.unsetColor();
+            }
+        });
+    }
+
     ViewControls.prototype.constructor = ViewControls;
     ViewControls.prototype.setZoomControls = setZoomControls;
     ViewControls.prototype.setOpacityControls = setOpacityControls;
     ViewControls.prototype.setBackgroundOpacityControls = setBackgroundOpacityControls;
-    ViewControls.prototype.shouldHideText = shouldHideText;
     ViewControls.prototype.setSylControls = setSylControls;
     ViewControls.prototype.setOpacityFromSlider = setOpacityFromSlider;
+    ViewControls.prototype.setHighlightControls = setHighlightControls;
 }

--- a/views/editor.pug
+++ b/views/editor.pug
@@ -33,6 +33,8 @@ html
           a.panel-block
             label.checkbox Display Text: 
               input.checkbox#displayText(type="checkbox")
+            label.checkbox Highlight Staves:
+              input.checkbox#highlightStaves(type="checkbox")
           #insert_controls
           #edit_controls
         #neume_info


### PR DESCRIPTION
Adds a checkbox to toggle highlighting each staff and its elements. `ColorStaves.js` iterates through a palette that *should* be usable for people with color blindness. Does not interfere with color changes on selecting since they apply a fill to different elements.

Resolves #65 without needing even more listeners on the SVG elements. Since this doesn't depend on any editing/selecting features, this could be adapted into an update to the editor-only version of Neon in the master branch (and become v2.1.0).