### PR TITLE
Fix revert in standalone mode.

### DIFF
--- a/src/Compatibility.js
+++ b/src/Compatibility.js
@@ -66,9 +66,12 @@ export function saveFile(filename, mei) {
  */
 export function revertFile(filename) {
     if (mode === modes.standalone) {
+        var pathSplit = filename.split('/');
+        let file = pathSplit[pathSplit.length - 1];
         $.ajax({
             type: "POST",
-            url: "/revert/" + filename
+            url: "/revert/" + file,
+            success: () => { window.location.reload(); }
         });
     }
     else if (mode === modes.rodan) {

--- a/src/NeonView.js
+++ b/src/NeonView.js
@@ -44,7 +44,6 @@ function NeonView (params) {
         zoomHandler = new ZoomHandler();
         infoBox = new InfoBox(neon);
         Controls.initDisplayControls(zoomHandler);
-        console.log(neonview);
         editMode = new EditMode(neonview, meiFile, zoomHandler);
         loadView();
         // editMode.getScale();


### PR DESCRIPTION
Resolve #174.

We were passing the entire file path to revert, so it wasn't even being called on the server since the file path didn't match the pattern. This now works and when the POST request is successful, Neon will automatically refresh the page, loading the reverted page.