### PR TITLE
Don't reselect on click if element already selected

### DIFF
--- a/src/DragHandler.js
+++ b/src/DragHandler.js
@@ -15,7 +15,7 @@ function DragHandler (neonView) {
         var dragBehaviour = d3.drag().on("start", dragStarted)
             .on("drag", dragging)
             .on("end", dragEnded);
-        
+
         var activeNc = d3.selectAll(".selected");
         var selection = Array.from(activeNc._groups[0]);
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -36,12 +36,10 @@ export function ClickSelect (dragHandler, zoomHandler, neonView) {
                     }
                 }
                 else if ($("#selBySyl").hasClass("is-active") && isNc) {
-                    console.log("Test");
                     var ncParent = $(this).parent();
                     var neumeParent = $(this).parent().parent();
                     if($(neumeParent).hasClass("neume")){
                         var parentSiblings = Array.from($(neumeParent).siblings(".neume"));
-                        console.log("Neume siblings: " + parentSiblings.length);
                         if(parentSiblings.length != 0){
                             selectSyl(this, dragHandler);
                         }
@@ -547,7 +545,6 @@ function select(el) {
  * @param {DragHandler} dragHandler - An instantiated DragHandler.
  */
 function selectSyl(el, dragHandler) {
-    console.log($(el).parent().parent().parent().attr("class"));
     if(!$(el).parent().parent().parent().hasClass("selected")){
         unselect();
         select($(el).parent().parent().parent());

--- a/src/Select.js
+++ b/src/Select.js
@@ -36,14 +36,16 @@ export function ClickSelect (dragHandler, zoomHandler, neonView) {
                     }
                 }
                 else if ($("#selBySyl").hasClass("is-active") && isNc) {
+                    console.log("Test");
                     var ncParent = $(this).parent();
                     var neumeParent = $(this).parent().parent();
                     if($(neumeParent).hasClass("neume")){
                         var parentSiblings = Array.from($(neumeParent).siblings(".neume"));
+                        console.log("Neume siblings: " + parentSiblings.length);
                         if(parentSiblings.length != 0){
                             selectSyl(this, dragHandler);
                         }
-                        else{
+                        else if (!$(this).parent().parent().parent().hasClass("selected")){
                             var ncSiblings = Array.from($(ncParent).siblings(".nc"));
                             if(ncSiblings != 0){
                                 selectNeumes(this, dragHandler);
@@ -62,7 +64,7 @@ export function ClickSelect (dragHandler, zoomHandler, neonView) {
                     if(siblings.length != 0) {
                         selectNeumes(this, dragHandler);
                     }
-                    else{
+                    else if (!$(this).parent().parent().hasClass("selected")){
                         selectNcs(this, dragHandler);
                     }
                 }
@@ -545,6 +547,7 @@ function select(el) {
  * @param {DragHandler} dragHandler - An instantiated DragHandler.
  */
 function selectSyl(el, dragHandler) {
+    console.log($(el).parent().parent().parent().attr("class"));
     if(!$(el).parent().parent().parent().hasClass("selected")){
         unselect();
         select($(el).parent().parent().parent());


### PR DESCRIPTION
With all the contextual selection (ie selecting a syllable as a neume if
it's one neume) make sure to check that the syllable wasn't already part
of a selection. Keeps from interfering with drag selections and dragging
these selections.

Resolve #207.