### PR TITLE
Run highlight on selection and don't override select fill

### DIFF
--- a/src/Color.js
+++ b/src/Color.js
@@ -14,8 +14,14 @@ export function setGroupingHighlight(grouping) {
     let groups = Array.from($("." + grouping));
     for (var i = 0; i < groups.length; i++) {
         let groupColor = ColorPalette[i % ColorPalette.length];
-        groups[i].setAttribute("fill", groupColor);
-        $(groups[i]).addClass("highlighted");
+        if (!$(groups[i]).parents(".selected").length) {
+            groups[i].setAttribute("fill", groupColor);
+            $(groups[i]).addClass("highlighted");
+        } else {
+            console.log(groups[i].id);
+            groups[i].setAttribute("fill", null);
+            $(groups[i]).removeClass("highlighted");
+        }
     }
 }
 

--- a/src/Color.js
+++ b/src/Color.js
@@ -18,7 +18,6 @@ export function setGroupingHighlight(grouping) {
             groups[i].setAttribute("fill", groupColor);
             $(groups[i]).addClass("highlighted");
         } else {
-            console.log(groups[i].id);
             groups[i].setAttribute("fill", null);
             $(groups[i]).removeClass("highlighted");
         }

--- a/src/Select.js
+++ b/src/Select.js
@@ -581,6 +581,7 @@ function select(el) {
         $(el).attr("fill", "#d00");
         $(el).addClass("selected");
     }
+    Controls.updateHighlight();
 }
 
 /**


### PR DESCRIPTION
Run the updateHighlight function when selecting a new element. Also when
updating a highlight by grouping ensure a parent in the DOM hierarchy is
not marked as selected. If so don't apply the highlight (since it will
override the selection fill on a higher up element).

Resolve #220.