### PR TITLE
Feature/pages version improvements

### DIFF
--- a/pages/editor.js
+++ b/pages/editor.js
@@ -1,9 +1,8 @@
-import CF018_MEI from "./CF018.mei";
-import CF018_BG from "./CF018.png";
 import NeonView from "../src/NeonView.js";
 
+var params = JSON.parse(decodeURIComponent(window.location.search.substr(1).split('=')[1]));
 var view = new NeonView({
-    meifile: CF018_MEI,
-    bgimg: CF018_BG,
+    meifile: "./" + params.mei,
+    bgimg: "./" + params.img,
     mode: "pages"
 });

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,29 @@
+import CF009_MEI from "./CF009.mei";
+import CF009_BG from "./CF009.png";
+import CF018_MEI from "./CF018.mei";
+import CF018_BG from "./CF018.png";
+
+/**
+ * Pages that can be loaded.
+ * @type {{name: string, mei: string, img: string}[]}
+ */
+const selectionOptions = [
+    {
+        name: "CF009",
+        mei: CF009_MEI,
+        img: CF009_BG
+    },
+    {
+        name: "CF018",
+        mei: CF018_MEI,
+        img: CF018_BG
+    }
+];
+
+let selector = document.getElementById("page-selector");
+selectionOptions.forEach(option => {
+    var elem = document.createElement('option');
+    elem.setAttribute("value", '{"mei":"' + option.mei + '","img":"' + option.img + '"}');
+    elem.innerHTML = option.name;
+    selector.appendChild(elem);
+});

--- a/src/Compatibility.js
+++ b/src/Compatibility.js
@@ -62,7 +62,13 @@ export function saveFile(filename, mei) {
         console.warn("Rodan save not yet implemented!");
     }
     else if (mode === modes.pages) {
-        console.warn("Saving is not supported on GitHub Pages!");
+        var temp = document.createElement('a');
+        temp.setAttribute("href", "data:application/mei+xml;charset=utf-8," + encodeURIComponent(mei));
+        temp.setAttribute("download", file);
+        temp.style.display = "none";
+        document.body.append(temp);
+        temp.click();
+        document.body.removeChild(temp);
     }
     else {
         console.error("Unsupported or unset mode!");
@@ -92,7 +98,7 @@ export function revertFile(filename) {
         });
     }
     else if (mode === modes.pages) {
-        console.warn("Revert for GH Pages not yet implemented!");
+        window.location.reload();   // No actions since the source file can't be overwritten
     }
     else {
         console.error("Unsupported or unset mode!");

--- a/webpack.pages-config.js
+++ b/webpack.pages-config.js
@@ -5,6 +5,7 @@ module.exports = {
     mode: "production",
     entry: {
         editor: "./pages/editor.js",
+        index: "./pages/index.js",
         pretty: "./src/pretty.js"
     },
     output: {


### PR DESCRIPTION
Improvements for the demo version of Neon on github pages. Add support for an index page to select a page to load (so CF018 isn't hard-coded). The HTML for that index page will be separately added to the `gh-pages` branch.

Also add saving and revert support in github pages. Revert is just reloading the page since the page is static and can't be overwritten. Save just opens a download for the MEI file with all changes made in the editor. This differs from the "Download MEI" option, which just downloads the file saved on the server. Since this file can't be changed in pages, it's just a link to the original version.