### PR TITLE
Prevent insert clickaway on other SVG elements.

### DIFF
--- a/src/InsertHandler.js
+++ b/src/InsertHandler.js
@@ -142,7 +142,8 @@ function InsertHandler (neonView) {
     }
 
     function clickawayHandler (evt) {
-        if(evt.target.id != "bgimg" && !($(evt.target).hasClass("insertel") || $(evt.target).hasClass("image"))) {
+        if(evt.target.id !== "svg_group" && $("#svg_group").find(evt.target).length === 0 && evt.target.tagName !== "path"
+            && !($(evt.target).hasClass("insertel") || $(evt.target).hasClass("image"))) {
             insertDisabled();
             $("body").off("keydown", staffHandler);
             $("body").off("keydown", handler);


### PR DESCRIPTION
Previously clickaway happened when the user clicked on a `path` element
that forms a staff line. Now it shouldn't disable insert mode without it
being a click outside of the entire svg container.

Resolve #240.