### PR TITLE
Move save hotkey to navbar init so it's called once.

### DIFF
--- a/src/Controls.js
+++ b/src/Controls.js
@@ -387,6 +387,11 @@ export function initNavbar(filename, neonView) {
     $("#save").on("click", () => {
         neonView.saveMEI();
     });
+    $("body").on("keydown", (evt) => {
+        if (evt.key === "s") {
+            neonView.saveMEI();
+        }
+    });
 
     $("#revert").on("click", function(){
         if (confirm("Reverting will cause all changes to be lost. Press OK to continue.")) {

--- a/src/NeonView.js
+++ b/src/NeonView.js
@@ -136,9 +136,6 @@ function NeonView (params) {
                         );
                         Cursor.updateCursorTo("grab");
                         break;
-                    case "s":
-                        saveMEI();
-                        break;
                     case "h":
                         $("#mei_output").css("visibility", "hidden");
                         break;


### PR DESCRIPTION
Previously was available on load in NeonView, making it available before
entering edit mode and sometimes adding multiple listeners to it.

Resolve #243.