### PR TITLE
Overlay notifications on canvas.

### DIFF
--- a/src/Notification.js
+++ b/src/Notification.js
@@ -57,7 +57,7 @@ function displayNotification(notification) {
             return;
         }
     }
-    $("#notification-content").append("<span class='neon-notification' id='" + notification.getId() + "'>" + notification.message + "</span> ");
+    $("#notification-content").append("<div class='neon-notification' id='" + notification.getId() + "'>" + notification.message + "</div> ");
     $("#notification-content").css("display", "");
     notification.display();
 }

--- a/src/style.css
+++ b/src/style.css
@@ -34,12 +34,19 @@ button:focus {
     overflow: auto;
 }
 
-span.neon-notification {
+#notification-content {
+    z-index: 8;
+    position: fixed;
+}
+
+.neon-notification {
     padding: 0.4rem;
-    margin: 0 0.25rem 0;
-    background-color: whitesmoke;
+    margin: 0.5rem;
+    background: #f5f5f577; /* whitesmoke with opacity */
     border: 0.05rem solid;
     border-radius: 1rem;
+    z-index: 8;
+    cursor: pointer;
 }
 
 .overlay {

--- a/views/editor.pug
+++ b/views/editor.pug
@@ -9,7 +9,6 @@ html(style={height: "100%", overflow: "hidden"})
       .navbar-brand
         a.navbar-item(href='../')
           p Neon3
-        a.navbar-item#notification-content(style={display: "none"})
         a.navbar-burger#burgerMenu(role="button" aria-label="menu" aria-expanded="false")
           span(aria-hidden="true")
           span(aria-hidden="true")
@@ -28,6 +27,7 @@ html(style={height: "100%", overflow: "hidden"})
               a.navbar-item(href="//ddmal.music.mcgill.ca" target="_blank") DDMAL
               a.navbar-item(onclick="hotkeyDialog()") Hotkeys
     .columns(style={overflow: "hidden", height: "94%", "margin": "0"})
+      #notification-content(style={display: "none"})
       .column#svg_output.is-two-thirds.box(style={overflow: "hidden", height: "getHeight()"})
       .column.is-one-third.is-hidden-mobile(style={"overflow-x": "hidden", "overflow-y": "auto"})
         .panel


### PR DESCRIPTION
Move notifications out of navbar. Behaviour otherwise the same.
Floating notification with half opacity background
Resolve #286.

This will require changes in [the wrapper](https://github.com/DDMAL/neon2-wrapper).