### PR TITLE
Fix select/drag issues from refactor/select merge.

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -37,7 +37,10 @@ export function ClickSelect (dragHandler, zoomHandler, neonView, neon) {
             })
             if (editing || evt.shiftKey) { return; }
             if (this.tagName === "use") {
-                selectAll([this], neon, neonView, dragHandler);
+                // If this was part of a drag select, drag don't reselect the one component
+                if ($(this).parents(".selected").length === 0) {
+                    selectAll([this], neon, neonView, dragHandler);
+                }
             }
             else {
                 if (!$("#selByStaff").hasClass("is-active")) {
@@ -296,7 +299,7 @@ function selectNn (notNeumes) {
  * @param {SVGSVGElement[]} elements - The elements to select. Either <g> or <use>.
  * @param {module:Neon~Neon} neon - A neon instance.
  * @param {NeonView} neonView - The NeonView parent.
- * @param {dragHandler} dragHandler - A DragHandler to alow staff resizing and some neume component selection cases.
+ * @param {DragHandler} dragHandler - A DragHandler to alow staff resizing and some neume component selection cases.
  */
 function selectAll (elements, neon, neonView, dragHandler) {
     var syls = [],
@@ -564,6 +567,7 @@ function selectAll (elements, neon, neonView, dragHandler) {
             SelectOptions.triggerNcActions(ncs[0]);
         }
     }
+    dragHandler.dragInit();
 }
 
 /**
@@ -647,7 +651,7 @@ function selectNcs (el, dragHandler, neon) {
             }
             Grouping.triggerGrouping("ligature");
         }
-        else if (parent.hasClass("nc")){
+        else if ($(parent).hasClass("nc")){
             SelectOptions.triggerNcActions(parent);
         }
         else{


### PR DESCRIPTION
Call `dragHandler.dragInit` on every new select action. Do not click
reselect on a part of an existing selection (since this is probably
dragging a drag selection, not making a new selection). Fix an issue
where we called a jquery method on an `HTMLElement`.

Check manually before merging into develop for correctness. It looked
good on my end but I might've missed something. Context options from `selectAll` seem right.

Also I found a `LogMessage` in `src/editortoolkit.cpp` under `EditorToolkit::Remove`. We don't need to rebuild it now but next time we make a change to verovio we should ensure that message isn't being sent every time `Remove` is called.