### PR TITLE
Bind hotkey to Shift+num for insert options.

### DIFF
--- a/src/Controls.js
+++ b/src/Controls.js
@@ -388,6 +388,13 @@ function bindElements(insertHandler) {
             activate(el, insertHandler);
             Cursor.updateCursor();
         });
+        document.body.addEventListener("keydown", (evt) => {
+            if (evt.code === "Digit" + (i+1) && evt.shiftKey) {
+                deactivate('.insertel');
+                activate(el, insertHandler);
+                Cursor.updateCursor();
+            }
+        });
     });
 }
 


### PR DESCRIPTION
Resolve #298. Use `addEventListener` so we can access `KeyboardEvent.code` since that is not copied in the jQuery event object.