### PR TITLE
Support dragging staves from any part of staff

### DIFF
--- a/src/DragHandler.js
+++ b/src/DragHandler.js
@@ -29,12 +29,14 @@ function DragHandler (neonView) {
         // Drag effects
         function dragStarted () {
             dragStartCoords = d3.mouse(this);
+            if (this.classList.contains("staff")) {
+                d3.select("#svg_group").call(dragBehaviour);
+            }
         }
 
         function dragging () {
             var relativeY = d3.event.y - dragStartCoords[1];
             var relativeX = d3.event.x - dragStartCoords[0];
-
             selection.forEach((el) => {
                 d3.select(el).attr("transform", function() {
                     return "translate(" + [relativeX, relativeY] + ")"
@@ -65,6 +67,7 @@ function DragHandler (neonView) {
                 neonView.refreshPage();
                 endOptionsSelection();
             }
+            d3.select("#svg_group").on(".drag", null);
             dragInit();
         }
     }

--- a/src/Select.js
+++ b/src/Select.js
@@ -69,7 +69,20 @@ export function ClickSelect (dragHandler, zoomHandler, neonView, neon) {
                     SelectOptions.triggerSplitActions();
                     let resize = new Resize(staff.id, neonView, dragHandler);
                     resize.drawInitialRect();
+                    // Start staff dragging
+                    dragHandler.dragInit();
                 }
+                staff.dispatchEvent(new MouseEvent("mousedown", {
+                    screenX: evt.screenX,
+                    screenY: evt.screenY,
+                    clientX: evt.clientX,
+                    clientY: evt.clientY,
+                    ctrlKey: evt.ctrlKey,
+                    shiftKey: evt.shiftKey,
+                    altKey: evt.altKey,
+                    metaKey: evt.metaKey,
+                    view: evt.view
+                }));
             }
         }
 


### PR DESCRIPTION
Now dragging a staff and its elements can be done by clicking anywhere
within the staff and not just on the actual SVG elements. This was done
by sending a `mousedown` action to the staff SVG when click selecting
off the SVG and, in that case, temporarily setting the dragging actions
to use `#svg_group` as a source for `mousemove` and `mouseup` actions.

Resolve #296.