### PR TITLE
Fix toggling ligatures with non-punctums, fix drag select

### DIFF
--- a/src/DragHandler.js
+++ b/src/DragHandler.js
@@ -6,6 +6,7 @@
 function DragHandler (neonView) {
     var dragStartCoords;
     var dragEndCoords;
+    var resetToAction;
 
     /**
      * Initialize the dragging action and handler for selected elements.
@@ -67,9 +68,18 @@ function DragHandler (neonView) {
                 neonView.refreshPage();
                 endOptionsSelection();
             }
-            d3.select("#svg_group").on(".drag", null);
+
+            reset();
             dragInit();
         }
+    }
+
+    function resetTo(reset) {
+        resetToAction = reset;
+    }
+
+    function reset() {
+        d3.select("#svg_group").call(resetToAction);
     }
 
     function endOptionsSelection () {
@@ -78,6 +88,7 @@ function DragHandler (neonView) {
     }
 
     DragHandler.prototype.dragInit = dragInit;
+    DragHandler.prototype.resetTo = resetTo;
 }
 
 export {DragHandler as default};

--- a/src/Grouping.js
+++ b/src/Grouping.js
@@ -3,6 +3,7 @@
 import * as Contents from "./Contents.js";
 import * as Warnings from "./Warnings.js";
 import * as Notification from "./Notification.js";
+import {unsetVirgaAction, unsetInclinatumAction} from "./SelectOptions.js";
 import InfoBox from "./InfoBox.js";
 
 /**
@@ -72,6 +73,11 @@ export function initGroupingListeners(){
             isLigature = true;
         } else {
             isLigature = false;
+            let chainAction = { "action": "chain", "param": [
+                unsetInclinatumAction(elementIds[0]), unsetVirgaAction(elementIds[0]),
+                unsetInclinatumAction(elementIds[1]), unsetVirgaAction(elementIds[1])
+            ]};
+            neonView.edit(chainAction);
         }
 
         let editorAction = {

--- a/src/InsertHandler.js
+++ b/src/InsertHandler.js
@@ -18,6 +18,7 @@ function InsertHandler (neonView) {
      * @param {string} buttonId - The ID of the button pressed.
      */
     function insertActive (buttonId) {
+        let alreadyInInsertMode = isInsertMode();
         if (buttonId === "punctum") {
             type = "nc";
             attributes = null;
@@ -124,14 +125,16 @@ function InsertHandler (neonView) {
         $("body").on("click", clickawayHandler);
 
         // Add 'return to edit mode' button
-        let editModeContainer = document.createElement("p");
-        editModeContainer.classList.add("control");
-        let editModeButton = document.createElement("button");
-        editModeButton.id = "returnToEditMode";
-        editModeButton.classList.add("button");
-        editModeButton.innerHTML = "Return to Edit Mode";
-        editModeContainer.appendChild(editModeButton);
-        document.getElementById("delete").parentNode.parentNode.appendChild(editModeContainer);
+        if (!alreadyInInsertMode) {
+            let editModeContainer = document.createElement("p");
+            editModeContainer.classList.add("control");
+            let editModeButton = document.createElement("button");
+            editModeButton.id = "returnToEditMode";
+            editModeButton.classList.add("button");
+            editModeButton.innerHTML = "Return to Edit Mode";
+            editModeContainer.appendChild(editModeButton);
+            document.getElementById("delete").parentNode.parentNode.appendChild(editModeContainer);
+        }
 
         editModeButton.addEventListener("click", insertDisabled);
 

--- a/src/Select.js
+++ b/src/Select.js
@@ -128,12 +128,12 @@ export function DragSelect (dragHandler, zoomHandler, neonView, neon, infoBox) {
         dragSelecting = false;
 
     var canvas = d3.select("#svg_group");
-    canvas.call(
-        d3.drag()
-            .on("start", selStart)
-            .on("drag", selecting)
-            .on("end", selEnd)
-    );
+    var dragSelectAction = d3.drag()
+        .on("start", selStart)
+        .on("drag", selecting)
+        .on("end", selEnd);
+    canvas.call(dragSelectAction);
+    dragHandler.resetTo(dragSelectAction);
 
     /**
      * Start drag selecting musical elements.

--- a/src/SelectOptions.js
+++ b/src/SelectOptions.js
@@ -20,6 +20,38 @@ export function initNeonView(view) {
     Grouping.initNeonView(view);
 }
 
+/**
+ * Return a JSON action that unsets the inclinatum parameter of an nc.
+ * @param {string} id - The id of the neume component.
+ * @returns {object}
+ */
+export function unsetInclinatumAction(id) {
+    return {
+        "action": "set",
+        "param": {
+            "elementId": id,
+            "attrType": "name",
+            "attrValue": ""
+        }
+    };
+}
+
+/**
+ * Return a JSON action that unsets the virga parameter of an nc.
+ * @param {string} id - The id of the neume component.
+ * @returns {object}
+ */
+export function unsetVirgaAction(id) {
+    return {
+        "action": "set",
+        "param": {
+            "elementId": id,
+            "attrType": "diagonalright",
+            "attrValue": ""
+        }
+    };
+}
+
 //TODO: CHANGE NAVABAR-LINK TO PROPER ICON//
 /**
  * Trigger the extra nc action menu.
@@ -31,22 +63,8 @@ export function triggerNcActions(nc) {
     $("#moreEdit").append(Contents.ncActionContents);
 
     $("#Punctum.dropdown-item").on("click", (evt) => {
-        let unsetInclinatum = {
-            "action": "set",
-            "param": {
-                "elementId": nc.id,
-                "attrType": "name",
-                "attrValue": ""
-            }
-        };
-        let unsetVirga = {
-            "action": "set",
-            "param": {
-                "elementId": nc.id,
-                "attrType": "diagonalright",
-                "attrValue": ""
-            }
-        };
+        let unsetInclinatum = unsetInclinatumAction(nc.id);
+        let unsetVirga = unsetVirgaAction(nc.id);
         if(neonView.edit({ "action": "chain", "param": [ unsetInclinatum, unsetVirga ]})){
             Notification.queueNotification("Shape Changed");
         }
@@ -66,14 +84,7 @@ export function triggerNcActions(nc) {
                 "attrValue": "inclinatum"
             }
         };
-        let unsetVirga = {
-            "action": "set",
-            "param": {
-                "elementId": nc.id,
-                "attrType": "diagonalright",
-                "attrValue": ""
-            }
-        };
+        let unsetVirga = unsetVirgaAction(nc.id);
         if(neonView.edit({ "action": "chain", "param": [ setInclinatum, unsetVirga ]})){
             Notification.queueNotification("Shape Changed");
         }
@@ -85,14 +96,7 @@ export function triggerNcActions(nc) {
     });
 
     $("#Virga.dropdown-item").on("click", (evt) => {
-        let unsetInclinatum = {
-            "action": "set",
-            "param": {
-                "elementId": nc.id,
-                "attrType": "name",
-                "attrValue": ""
-            }
-        };
+        let unsetInclinatum = unsetInclinatumAction(nc.id);
         let setVirga = {
             "action": "set",
             "param": {


### PR DESCRIPTION
Fixes issues #308 and #314.

When the user makes a call to set two neume components to become a ligature, now first both neume components have the virga and inclinatum parameters automatically unset. This allows them to render correctly and ensures the MEI makes sense, but toggling the ligature off does not restore these parameters.

Ensure the event listeners on `svg_group` are restored at the end of a drag action called from `DragHandler`. It was originally replaced and removed to get more intuitive on click staff dragging, but this required putting a listener for staff dragging on `svg_group`, which replaced the drag select listeners.