### PR TITLE
External verovio to avoid webpack issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "build": "./setup-verovio && webpack --config webpack.config.js",
         "test": "jest --silent",
         "doc": "jsdoc -d ./doc/ ./src/ -R ./README.md",
-        "pages": "./setup-verovio && webpack --config webpack.pages-config.js"
+        "pages": "./setup-verovio && webpack --config webpack.pages-config.js && cp public/verovio-toolkit.js dist/verovio-toolkit.js"
     },
     "jest": {
         "testPathIgnorePatterns": [

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     },
     "scripts": {
         "start": "nodemon server.js",
-        "build": "webpack --config webpack.config.js",
+        "build": "./setup-verovio && webpack --config webpack.config.js",
         "test": "jest --silent",
         "doc": "jsdoc -d ./doc/ ./src/ -R ./README.md",
-        "pages": "webpack --config webpack.pages-config.js"
+        "pages": "./setup-verovio && webpack --config webpack.pages-config.js"
     },
     "jest": {
         "testPathIgnorePatterns": [

--- a/setup-verovio
+++ b/setup-verovio
@@ -1,0 +1,15 @@
+#!/bin/bash
+# A helper script to deploy a plain verovio into a standalone JS toolkit
+# and an NPM module.
+
+## Make NPM Module
+
+cat verovio-util/verovio-npm-start.js verovio-util/verovio.js verovio-util/verovio-proxy.js \
+    verovio-util/verovio-npm-end.js > src/verovio-dev/index.js
+
+## Make regular toolkit
+
+cat verovio-util/verovio.js verovio-util/verovio-js-start.js verovio-util/verovio-proxy.js \
+    > public/verovio-toolkit.js
+
+cp public/verovio-toolkit.js dist/verovio-toolkit.js

--- a/setup-verovio
+++ b/setup-verovio
@@ -11,5 +11,3 @@ cat verovio-util/verovio-npm-start.js verovio-util/verovio.js verovio-util/verov
 
 cat verovio-util/verovio.js verovio-util/verovio-js-start.js verovio-util/verovio-proxy.js \
     > public/verovio-toolkit.js
-
-cp public/verovio-toolkit.js dist/verovio-toolkit.js

--- a/verovio-util/verovio-js-start.js
+++ b/verovio-util/verovio-js-start.js
@@ -1,0 +1,2 @@
+
+var verovio = verovio || {};

--- a/verovio-util/verovio-npm-end.js
+++ b/verovio-util/verovio-npm-end.js
@@ -1,0 +1,21 @@
+	// ... verovio-proxy.js preceed
+	
+	//console.log(Module.getMemory());
+	
+	// Check what to return - an instance, or the contructor method
+	if (createInstance) {
+		return new verovio.toolkit();
+	}
+	else {
+		return { toolkit:verovio.toolkit };	
+	}
+}
+
+// Minimal function
+verovio.toolkit = function() {
+	return init(0, true);
+}
+
+// Both exports
+module.exports = { toolkit:verovio.toolkit };
+module.exports.init = init;

--- a/verovio-util/verovio-npm-start.js
+++ b/verovio-util/verovio-npm-start.js
@@ -1,0 +1,29 @@
+
+var verovio = verovio || {};
+
+/*  beginning of the init function that adjsut the memory (if required) and load the module */
+
+init = function (memory, createInstance = false) {
+	
+	// If we ask for creating an instance are already have one, just call the contructor
+	if (createInstance && verovio.ptr != undefined) {
+		return new verovio.toolkit();
+	}
+	
+	var Module;if(typeof Module==="undefined")Module={};
+	if (memory > 0) {
+		if (memory < 256) {
+			console.warn("Memory setting ignore because it should be at least 256");
+		}
+		else if (memory >= 1024) {
+			console.warn("Memory setting ignored because it should be less than 1024");
+		}
+		else {
+			Module.TOTAL_MEMORY = 2*memory*1024*1024;
+			Module.TOTAL_STACK = memory*1024*1024;
+			console.info("Maxmimum memory increased to " + memory + "MB");
+		}
+	}
+	
+	// The verovio-proxy.js	follows...
+	

--- a/verovio-util/verovio-proxy.js
+++ b/verovio-util/verovio-proxy.js
@@ -1,0 +1,203 @@
+/***************************************************************************************************************************/
+// Proxy the exported c++ methods
+verovio.vrvToolkit = verovio.vrvToolkit || {};
+
+// Constructor and destructor
+// Toolkit *constructor()
+verovio.vrvToolkit.constructor = Module.cwrap('vrvToolkit_constructor', 'number', []);
+
+// void destructor(Toolkit *ic)
+verovio.vrvToolkit.destructor = Module.cwrap('vrvToolkit_destructor', null, ['number']);
+
+// bool edit(Toolkit *ic, const char *editorAction) 
+verovio.vrvToolkit.edit = Module.cwrap('vrvToolkit_edit', 'number', ['number', 'string']);
+
+// char *editInfo(Toolkit *ic)
+verovio.vrvToolkit.editInfo = Module.cwrap('vrvToolkit_editInfo', 'string', ['number']);
+
+// char *getAvailableOptions(Toolkit *ic)
+verovio.vrvToolkit.getAvailableOptions = Module.cwrap('vrvToolkit_getAvailableOptions', 'string', ['number']);
+
+// char *getElementAttr(Toolkit *ic, const char *xmlId)
+verovio.vrvToolkit.getElementAttr = Module.cwrap('vrvToolkit_getElementAttr', 'string', ['number', 'string']);
+
+// char *getElementsAtTime(Toolkit *ic, int time)
+verovio.vrvToolkit.getElementsAtTime = Module.cwrap('vrvToolkit_getElementsAtTime', 'string', ['number', 'number']);
+
+// char *getHumdrum(Toolkit *ic)
+verovio.vrvToolkit.getHumdrum = Module.cwrap('vrvToolkit_getHumdrum', 'string');
+
+// char *getLog(Toolkit *ic)
+verovio.vrvToolkit.getLog = Module.cwrap('vrvToolkit_getLog', 'string', ['number']);
+
+// char *getMEI(Toolkit *ic, int pageNo, int scoreBased)
+verovio.vrvToolkit.getMEI = Module.cwrap('vrvToolkit_getMEI', 'string', ['number', 'number', 'number']);
+
+// char *getOptions(Toolkit *ic, int defaultValues)
+verovio.vrvToolkit.getOptions = Module.cwrap('vrvToolkit_getOptions', 'string', ['number', 'number']);
+
+// int getPageCount(Toolkit *ic)
+verovio.vrvToolkit.getPageCount = Module.cwrap('vrvToolkit_getPageCount', 'number', ['number']);
+
+// int getPageWithElement(Toolkit *ic, const char *xmlId)
+verovio.vrvToolkit.getPageWithElement = Module.cwrap('vrvToolkit_getPageWithElement', 'number', ['number', 'string']);
+
+// double getTimeForElement(Toolkit *ic, const char *xmlId)
+verovio.vrvToolkit.getTimeForElement = Module.cwrap('vrvToolkit_getTimeForElement', 'number', ['number', 'string']);
+
+// char *getMIDIValuesForElement(Toolkit *ic, const char *xmlId)
+verovio.vrvToolkit.getMIDIValuesForElement = Module.cwrap('vrvToolkit_getMIDIValuesForElement', 'string', ['number', 'string']);
+
+// char *getVersion(Toolkit *ic)
+verovio.vrvToolkit.getVersion = Module.cwrap('vrvToolkit_getVersion', 'string', ['number']);
+
+// bool loadData(Toolkit *ic, const char *data)
+verovio.vrvToolkit.loadData = Module.cwrap('vrvToolkit_loadData', 'number', ['number', 'string']);
+
+// void redoLayout(Toolkit *ic)
+verovio.vrvToolkit.redoLayout = Module.cwrap('vrvToolkit_redoLayout', null, ['number']);
+
+// void redoPagePitchPosLayout(Toolkit *ic)
+verovio.vrvToolkit.redoPagePitchPosLayout = Module.cwrap('vrvToolkit_redoPagePitchPosLayout', null, ['number']);
+
+// char *renderData(Toolkit *ic, const char *data, const char *options)
+verovio.vrvToolkit.renderData = Module.cwrap('vrvToolkit_renderData', 'string', ['number', 'string', 'string']);
+
+// char *renderToMidi(Toolkit *ic, const char *rendering_options)
+verovio.vrvToolkit.renderToMIDI = Module.cwrap('vrvToolkit_renderToMIDI', 'string', ['number', 'string']);
+
+// char *renderToSvg(Toolkit *ic, int pageNo, const char *rendering_options)
+verovio.vrvToolkit.renderToSVG = Module.cwrap('vrvToolkit_renderToSVG', 'string', ['number', 'number', 'string']);
+
+// char *renderToTimemap(Toolkit *ic)
+verovio.vrvToolkit.renderToTimemap = Module.cwrap('vrvToolkit_renderToTimemap', 'string', ['number']);
+
+// void setOptions(Toolkit *ic, const char *options) 
+verovio.vrvToolkit.setOptions = Module.cwrap('vrvToolkit_setOptions', null, ['number', 'string']);
+
+// A pointer to the object - only one instance can be created for now
+verovio.instances = [];
+
+/***************************************************************************************************************************/
+
+verovio.toolkit = function () {
+	this.ptr = verovio.vrvToolkit.constructor();
+	console.debug("Creating toolkit instance");
+	verovio.instances.push(this.ptr);
+}
+
+verovio.toolkit.prototype.destroy = function () {
+	verovio.instances.splice(verovio.instances.indexOf(this.ptr), 1);
+	console.debug("Deleting toolkit instance");
+	verovio.vrvToolkit.destructor(this.ptr);
+};
+
+verovio.toolkit.prototype.edit = function (editorAction) {
+	return verovio.vrvToolkit.edit(this.ptr, JSON.stringify(editorAction));
+};
+
+verovio.toolkit.prototype.editInfo = function () {
+        return verovio.vrvToolkit.editInfo(this.ptr);
+};
+
+verovio.toolkit.prototype.getAvailableOptions = function () {
+	return JSON.parse(verovio.vrvToolkit.getAvailableOptions(this.ptr));
+};
+
+verovio.toolkit.prototype.getElementAttr = function (xmlId) {
+	return JSON.parse(verovio.vrvToolkit.getElementAttr(this.ptr, xmlId));
+};
+
+verovio.toolkit.prototype.getElementsAtTime = function (millisec) {
+	return JSON.parse(verovio.vrvToolkit.getElementsAtTime(this.ptr, millisec));
+};
+
+verovio.toolkit.prototype.getHumdrum = function () {
+	return verovio.vrvToolkit.getHumdrum(this.ptr);
+};
+
+verovio.toolkit.prototype.getLog = function () {
+	return verovio.vrvToolkit.getLog(this.ptr);
+};
+
+verovio.toolkit.prototype.getMEI = function (pageNo, scoreBased) {
+	return verovio.vrvToolkit.getMEI(this.ptr, pageNo, scoreBased);
+};
+
+verovio.toolkit.prototype.getMIDIValuesForElement = function (xmlId) {
+	return verovio.vrvToolkit.getMIDIValuesForElement(this.ptr, xmlId);
+};
+
+verovio.toolkit.prototype.getOptions = function (defaultValues) {
+	return JSON.parse(verovio.vrvToolkit.getOptions(this.ptr, defaultValues));
+};
+
+verovio.toolkit.prototype.getPageCount = function () {
+	return verovio.vrvToolkit.getPageCount(this.ptr);
+};
+
+verovio.toolkit.prototype.getPageWithElement = function (xmlId) {
+	return verovio.vrvToolkit.getPageWithElement(this.ptr, xmlId);
+};
+
+verovio.toolkit.prototype.getTimeForElement = function (xmlId) {
+	return verovio.vrvToolkit.getTimeForElement(this.ptr, xmlId);
+};
+
+verovio.toolkit.prototype.getVersion = function () {
+	return verovio.vrvToolkit.getVersion(this.ptr);
+};
+
+verovio.toolkit.prototype.loadData = function (data) {
+	return verovio.vrvToolkit.loadData(this.ptr, data);
+};
+
+verovio.toolkit.prototype.redoLayout = function () {
+	verovio.vrvToolkit.redoLayout(this.ptr);
+}
+
+verovio.toolkit.prototype.redoPagePitchPosLayout = function () {
+	verovio.vrvToolkit.redoPagePitchPosLayout(this.ptr);
+}
+
+verovio.toolkit.prototype.renderData = function (data, options) {
+	return verovio.vrvToolkit.renderData(this.ptr, data, JSON.stringify(options));
+};
+
+verovio.toolkit.prototype.renderPage = function (pageNo, options) {
+	console.warn("Method renderPage is deprecated; use renderToSVG instead");
+	return verovio.vrvToolkit.renderToSVG(this.ptr, pageNo, JSON.stringify(options));
+};
+
+verovio.toolkit.prototype.renderToMIDI = function (options) {
+	return verovio.vrvToolkit.renderToMIDI(this.ptr, JSON.stringify(options));
+};
+
+verovio.toolkit.prototype.renderToMidi = function (options) {
+	console.warn("Method renderToMidi is deprecated; use renderToMIDI instead");
+	return verovio.vrvToolkit.renderToMIDI(this.ptr, JSON.stringify(options));
+};
+
+verovio.toolkit.prototype.renderToSVG = function (pageNo, options) {
+	return verovio.vrvToolkit.renderToSVG(this.ptr, pageNo, JSON.stringify(options));
+};
+
+verovio.toolkit.prototype.renderToTimemap = function () {
+	return JSON.parse(verovio.vrvToolkit.renderToTimemap(this.ptr));
+};
+
+verovio.toolkit.prototype.setOptions = function (options) {
+	verovio.vrvToolkit.setOptions(this.ptr, JSON.stringify(options));
+};
+
+/***************************************************************************************************************************/
+
+// If the window object is defined (if we are not within a WebWorker)...
+if ((typeof window !== "undefined") && (window.addEventListener)) {
+	// Add a listener that will delete the object (if necessary) when the page is closed
+	window.addEventListener("unload", function () {
+		for (var i = 0; i < verovio.instances.length; i++) {
+			verovio.vrvToolkit.destructor(verovio.instances[i]);
+		}
+	});
+}

--- a/views/editor.pug
+++ b/views/editor.pug
@@ -2,6 +2,9 @@ html
   head
     title Neon3
     script(src='/pretty.js')
+    script(src='/verovio-toolkit.js')
+    script(src='//code.jquery.com/jquery-3.1.0.js' integrity='sha256-slogkvB1K3VOkzAI8QITxV3VzpOnkeNVsKvtkYLMjfk=' crossorigin='anonymous')
+    script(src='//cdnjs.cloudflare.com/ajax/libs/d3/5.5.0/d3.min.js' integrity='sha256-0OcjjB7oKWCwru7gzilCYvXgTE9augkyvMI0WFC1ODg=' crossorigin='anonymous')
   body
     .overlay#loading
       .loader

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,9 @@ module.exports = {
       }
     ]
   },
-  optimization: {
-    minimize: false
+  externals: {
+    'verovio-dev': 'verovio',
+    jquery: 'jQuery',
+    d3: 'd3'
   }
 };

--- a/webpack.pages-config.js
+++ b/webpack.pages-config.js
@@ -49,7 +49,9 @@ module.exports = {
       }
     ]
   },
-  optimization: {
-    minimize: false
+  externals: {
+    'verovio-dev': 'verovio',
+    jquery: 'jQuery',
+    d3: 'd3'
   }
 };


### PR DESCRIPTION
Rather than putting the verovio module into a single Neon2 editor.js
file, we distribute it separately and use webpack to handle loading.
Tests still pass and the NPM module is still available.

The same is done for jquery and d3 since they are likely to be cached.