### PR TITLE
fix: order elements based on DOM order in `hasInvalidSyllable`

### DIFF
--- a/src/SquareEdit/Grouping.ts
+++ b/src/SquareEdit/Grouping.ts
@@ -110,6 +110,18 @@ function containsLinked(
 function hasInvalidLinkedSyllable(
   elements: Array<SVGGraphicsElement>,
 ): boolean {
+  // Sort elements based on their order in the DOM
+  elements.sort((a, b) => {
+    if (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) {
+      return -1;
+    } else if (
+      a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_PRECEDING
+    ) {
+      return 1;
+    }
+    return 0;
+  });
+
   for (let idx = 0; idx < elements.length; idx++) {
     const syllable = elements.at(idx);
     if (syllable.hasAttribute('mei:precedes')) {

--- a/src/utils/SelectTools.ts
+++ b/src/utils/SelectTools.ts
@@ -1,8 +1,5 @@
 import * as Color from './Color';
-import {
-  updateHighlight,
-  getHighlightType,
-} from '../DisplayPanel/DisplayControls';
+import { updateHighlight } from '../DisplayPanel/DisplayControls';
 import * as Grouping from '../SquareEdit/Grouping';
 import { resize } from './Resize';
 import { Attributes, SelectionType } from '../Types';


### PR DESCRIPTION
- Needed for cases when the user selects the middle syllables in linked syllable sandwich

refs: https://github.com/DDMAL/Neon/issues/1253#issuecomment-2614601119