### PR TITLE
fix: use default svg id from verovio instead of `#mei_output`

### DIFF
--- a/cypress/e2e/buttons.cy.ts
+++ b/cypress/e2e/buttons.cy.ts
@@ -4,7 +4,9 @@ describe('visual: activate sidebar buttons', () => {
   beforeEach(() => {
     cy.viewport('macbook-13');
     cy.visit('http://localhost:8080/editor.html?manifest=test');
-    cy.get('#mei_output', { timeout: 10000 }).should('be.visible');
+    cy.get('svg.neon-container.active-page', { timeout: 10000 }).should(
+      'be.visible',
+    );
   });
 
   it('class: buttons should have `is-active` class when clicked', () => {

--- a/cypress/e2e/displace.cy.ts
+++ b/cypress/e2e/displace.cy.ts
@@ -1,7 +1,9 @@
 beforeEach(() => {
   cy.viewport('macbook-13');
   cy.visit('http://localhost:8080/editor.html?manifest=test');
-  cy.get('#mei_output', { timeout: 10000 }).should('be.visible');
+  cy.get('svg.neon-container.active-page', { timeout: 10000 }).should(
+    'be.visible',
+  );
 });
 
 describe('displace: +1 octave', () => {
@@ -43,7 +45,7 @@ describe('displace: +1 octave', () => {
 
       cy.get('#increment-octave').click({ timeout: 100, force: true });
 
-      cy.get(NEUME_ID).then($neume => {
+      cy.get(NEUME_ID).then(($neume) => {
         const after = $neume[0].getBoundingClientRect();
 
         // The neume should not have been moved, give or take 1px

--- a/cypress/e2e/drag/bboxes.cy.ts
+++ b/cypress/e2e/drag/bboxes.cy.ts
@@ -4,7 +4,9 @@
 
 beforeEach(() => {
   cy.visit('http://localhost:8080/editor.html?manifest=test');
-  cy.get('#mei_output', { timeout: 10000 }).should('be.visible');
+  cy.get('svg.neon-container.active-page', { timeout: 10000 }).should(
+    'be.visible',
+  );
 });
 
 describe('drag: bounding boxes', () => {
@@ -18,18 +20,20 @@ describe('drag: bounding boxes', () => {
 
   const BBOX_ID = '#m-8e6837fc-19d4-42c9-8266-cd54bb6f1dea';
 
-  it('coords(safe): move bbox in the x-direction', () => dragBBox(BBOX_ID, 350, 0));
-  it('coords(safe): move bbox in the y-direction', () => dragBBox(BBOX_ID, 0, 200));
-  it('coords(safe): move bbox in both directions', () => dragBBox(BBOX_ID, 100, 100));
-
+  it('coords(safe): move bbox in the x-direction', () =>
+    dragBBox(BBOX_ID, 350, 0));
+  it('coords(safe): move bbox in the y-direction', () =>
+    dragBBox(BBOX_ID, 0, 200));
+  it('coords(safe): move bbox in both directions', () =>
+    dragBBox(BBOX_ID, 100, 100));
 });
 
 /**
  * Drag function for bounding boxes:
  * Checks for whether the bounding box has moved correctly on mouseup
  */
-function dragBBox (selector: string, offsetX = 0, offsetY = 0): void {
-  cy.window().then(win => {
+function dragBBox(selector: string, offsetX = 0, offsetY = 0): void {
+  cy.window().then((win) => {
     cy.get(selector)
       .click()
       .then(($bbox) => {
@@ -37,12 +41,13 @@ function dragBBox (selector: string, offsetX = 0, offsetY = 0): void {
         // https://docs.cypress.io/guides/core-concepts/variables-and-aliases#Closures
         const origin = $bbox[0].getBoundingClientRect();
 
-        cy.get(selector).trigger('mousedown', { view: win, force: true, timeout: 100 })
+        cy.get(selector)
+          .trigger('mousedown', { view: win, force: true, timeout: 100 })
           .trigger('mousemove', offsetX, offsetY, { force: true })
           .trigger('mouseup', { view: win, force: true })
           .then(($bbox) => {
             const moved = $bbox[0].getBoundingClientRect();
-            
+
             // Bounding box coordinate checks:
             // We allow for some leeway on how close the positions have to be,
             // for any calculation rounding in d3 and Neon
@@ -55,10 +60,8 @@ function dragBBox (selector: string, offsetX = 0, offsetY = 0): void {
   });
 }
 
-
 Cypress.on('uncaught:exception', () => {
   // returning false here prevents Cypress from
   // failing the test
   return false;
 });
-

--- a/cypress/e2e/drag/custos.cy.ts
+++ b/cypress/e2e/drag/custos.cy.ts
@@ -1,12 +1,18 @@
 /**
  * Drag function for syllables and staves
  */
-function drag (selector: string, offsetX = 0, offsetY = 0): void {
+function drag(selector: string, offsetX = 0, offsetY = 0): void {
   // https://github.com/cypress-io/cypress/issues/3441#issuecomment-545292552
-  cy.window().then(win => {
-    cy.get(selector).first()
+  cy.window().then((win) => {
+    cy.get(selector)
+      .first()
       .click({ timeout: 100, force: true })
-      .trigger('mousedown', 1, 1, { timeout: 100, force: true, which: 1, view: win })
+      .trigger('mousedown', 1, 1, {
+        timeout: 100,
+        force: true,
+        which: 1,
+        view: win,
+      })
       .trigger('mousemove', offsetX + 1, offsetY + 1, { force: true })
       .trigger('mouseup', { force: true, view: win });
   });
@@ -18,9 +24,11 @@ beforeEach(() => {
     onBeforeLoad(win) {
       cy.stub(win.console, 'log').as('consoleLog');
       cy.stub(win.console, 'error').as('consoleError');
-    }
+    },
   });
-  cy.get('#mei_output', { timeout: 10000 }).should('be.visible');
+  cy.get('svg.neon-container.active-page', { timeout: 10000 }).should(
+    'be.visible',
+  );
 });
 
 describe('drag: custos', () => {
@@ -31,7 +39,7 @@ describe('drag: custos', () => {
 
   it('test: custos should be moved', () => {
     const CUSTOS_ID = '#m-4491f296-9c5b-4fb5-a4ec-5fb3d6ece0f8';
-    
+
     cy.get(CUSTOS_ID).trigger('mouseover', { force: true, timeout: 100 });
     cy.get('#element_info').should('contain', 'F2');
 

--- a/cypress/e2e/drag/staves.cy.ts
+++ b/cypress/e2e/drag/staves.cy.ts
@@ -1,12 +1,18 @@
 /**
  * Drag function for syllables and staves
  */
-function drag (selector: string, offsetX = 0, offsetY = 0): void {
+function drag(selector: string, offsetX = 0, offsetY = 0): void {
   // https://github.com/cypress-io/cypress/issues/3441#issuecomment-545292552
-  cy.window().then(win => {
-    cy.get(selector).first()
+  cy.window().then((win) => {
+    cy.get(selector)
+      .first()
       .click({ timeout: 100, force: true })
-      .trigger('mousedown', 1, 1, { timeout: 100, force: true, which: 1, view: win })
+      .trigger('mousedown', 1, 1, {
+        timeout: 100,
+        force: true,
+        which: 1,
+        view: win,
+      })
       .trigger('mousemove', offsetX + 1, offsetY + 1, { force: true })
       .trigger('mouseup', { force: true, view: win });
   });
@@ -14,7 +20,9 @@ function drag (selector: string, offsetX = 0, offsetY = 0): void {
 
 beforeEach(() => {
   cy.visit('http://localhost:8080/editor.html?manifest=test');
-  cy.get('#mei_output', { timeout: 10000 }).should('be.visible');
+  cy.get('svg.neon-container.active-page', { timeout: 10000 }).should(
+    'be.visible',
+  );
 });
 
 describe('drag: staves', () => {
@@ -23,18 +31,22 @@ describe('drag: staves', () => {
   });
 
   it('error: move out of bounds to the LEFT', () => {
-    cy.get('.staff').first().then(el => {
-      const origin = el[0].getBoundingClientRect();
+    cy.get('.staff')
+      .first()
+      .then((el) => {
+        const origin = el[0].getBoundingClientRect();
 
-      drag('.staff', -300, -0);
+        drag('.staff', -300, -0);
 
-      cy.get('.staff').first().then(el => {
-        const { x, y } = el[0].getBoundingClientRect();
+        cy.get('.staff')
+          .first()
+          .then((el) => {
+            const { x, y } = el[0].getBoundingClientRect();
 
-        expect(x).to.be.closeTo(origin.x, 15);
-        expect(y).to.be.closeTo(origin.y, 15);
+            expect(x).to.be.closeTo(origin.x, 15);
+            expect(y).to.be.closeTo(origin.y, 15);
+          });
       });
-    });
 
     // User should be notified
     cy.contains('Drag action failed').should('be.visible');
@@ -49,7 +61,7 @@ describe('drag: staves', () => {
     drag('.staff', 0, -300);
     cy.contains('Drag action failed').should('be.visible');
   });
-  
+
   it('error: move out of bounds to the BOTTOM', () => {
     drag('.staff', 0, 1000);
     cy.contains('Drag action failed').should('be.visible');
@@ -59,8 +71,7 @@ describe('drag: staves', () => {
     drag('.staff', 50, -30);
 
     // Staff should still be selected even after drag
-    cy.get('.staff').first()
-      .should('have.class', 'selected');
+    cy.get('.staff').first().should('have.class', 'selected');
 
     cy.contains('Drag action failed').should('not.exist');
   });

--- a/cypress/e2e/drag/syllables.cy.ts
+++ b/cypress/e2e/drag/syllables.cy.ts
@@ -1,12 +1,18 @@
 /**
  * Drag function for syllables and staves
  */
-function drag (selector: string, offsetX = 0, offsetY = 0): void {
+function drag(selector: string, offsetX = 0, offsetY = 0): void {
   // https://github.com/cypress-io/cypress/issues/3441#issuecomment-545292552
-  cy.window().then(win => {
-    cy.get(selector).first()
+  cy.window().then((win) => {
+    cy.get(selector)
+      .first()
       .click({ timeout: 100, force: true })
-      .trigger('mousedown', 1, 1, { timeout: 100, force: true, which: 1, view: win })
+      .trigger('mousedown', 1, 1, {
+        timeout: 100,
+        force: true,
+        which: 1,
+        view: win,
+      })
       .trigger('mousemove', offsetX + 1, offsetY + 1, { force: true })
       .trigger('mouseup', { force: true, view: win });
   });
@@ -14,7 +20,9 @@ function drag (selector: string, offsetX = 0, offsetY = 0): void {
 
 beforeEach(() => {
   cy.visit('http://localhost:8080/editor.html?manifest=test');
-  cy.get('#mei_output', { timeout: 10000 }).should('be.visible');
+  cy.get('svg.neon-container.active-page', { timeout: 10000 }).should(
+    'be.visible',
+  );
 });
 
 //
@@ -56,7 +64,6 @@ describe('drag: syllables', () => {
 
     // Syllable should still be selected even after drag
     cy.get(SYLLABLE_ID).should('have.class', 'selected');
-
   });
 });
 

--- a/cypress/e2e/dropdown.cy.ts
+++ b/cypress/e2e/dropdown.cy.ts
@@ -2,7 +2,9 @@ describe('test: dropdowns', () => {
   beforeEach(() => {
     cy.viewport('macbook-13');
     cy.visit('http://localhost:8080/editor.html?manifest=test');
-    cy.get('#mei_output', { timeout: 10000 }).should('be.visible');
+    cy.get('svg.neon-container.active-page', { timeout: 10000 }).should(
+      'be.visible',
+    );
   });
 
   function isOctaveDropdown(visible = true) {
@@ -43,5 +45,4 @@ describe('test: dropdowns', () => {
     cy.get('body').click({ force: true });
     isOctaveDropdown(false);
   });
-
 });

--- a/cypress/e2e/errorlog.cy.ts
+++ b/cypress/e2e/errorlog.cy.ts
@@ -8,7 +8,9 @@ describe('test: error log', () => {
     cy.viewport('macbook-13');
     cy.clearLocalStorage();
     cy.visit('http://localhost:8080/editor.html?manifest=test');
-    cy.get('#mei_output', { timeout: 10000 }).should('be.visible');
+    cy.get('svg.neon-container.active-page', { timeout: 10000 }).should(
+      'be.visible',
+    );
     cy.get('#debug-mode-checkbox').click({ timeout: 100, force: true });
   });
 

--- a/cypress/e2e/opacity.cy.ts
+++ b/cypress/e2e/opacity.cy.ts
@@ -1,24 +1,24 @@
 beforeEach(() => {
   cy.viewport('macbook-13');
   cy.visit('http://localhost:8080/editor.html?manifest=test');
-  cy.get('#mei_output', { timeout: 10000 }).should('be.visible');
+  cy.get('svg.neon-container.active-page', { timeout: 10000 }).should(
+    'be.visible',
+  );
 });
 
 type OpacityType = 'glyph' | 'bg';
 
-function expectOpacity (type: OpacityType, val: number) {
+function expectOpacity(type: OpacityType, val: number) {
   if (type === 'glyph') {
-    cy.get('#opacitySlider').as('range')
-      .should('have.value', val);
+    cy.get('#opacitySlider').as('range').should('have.value', val);
 
-    cy.get('#mei_output')
+    cy.get('svg.neon-container.active-page')
       .should('have.css', 'opacity')
       .and('eq', String(val / 100));
 
     cy.get('#opacityOutput').should('have.text', String(val));
   } else {
-    cy.get('#bgOpacitySlider').as('range')
-      .should('have.value', val);
+    cy.get('#bgOpacitySlider').as('range').should('have.value', val);
 
     cy.get('#bgimg')
       .should('have.css', 'opacity')
@@ -28,16 +28,17 @@ function expectOpacity (type: OpacityType, val: number) {
   }
 }
 
-function expectToggleButton (type: OpacityType, val: number) {
+function expectToggleButton(type: OpacityType, val: number) {
   cy.get(`#toggle-${type}-opacity > .slider-btn-img`)
     .should('have.attr', 'src')
     .and('contain', val === 0 ? 'show-icon' : 'hide-icon');
 }
 
-function setOpacity (type: OpacityType, val: number) {
+function setOpacity(type: OpacityType, val: number) {
   const sliderId = type === 'glyph' ? '#opacitySlider' : '#bgOpacitySlider';
 
-  cy.get(sliderId).as('range')
+  cy.get(sliderId)
+    .as('range')
     .trigger('mousedown')
     .invoke('val', val)
     .trigger('change') // Zoom slider uses mouseup, but glyph/img opacity uses change event
@@ -49,14 +50,16 @@ function setOpacity (type: OpacityType, val: number) {
 
 // Click the toggle button for the corresponding opacity type:
 // Check opacity value to be set to 0 or 100, as expected
-function clickToggle (type: OpacityType) {
+function clickToggle(type: OpacityType) {
   const sliderId = type === 'glyph' ? '#opacitySlider' : '#bgOpacitySlider';
-  cy.get(sliderId).as('range').then(($slider: JQuery<HTMLInputElement>) => {
-    const originVal = Number($slider[0].value);
-    cy.get(`#toggle-${type}-opacity`).click();
-    expectOpacity(type, originVal === 0 ? 100 : 0);
-    expectToggleButton(type, originVal === 0 ? 100 : 0);
-  });
+  cy.get(sliderId)
+    .as('range')
+    .then(($slider: JQuery<HTMLInputElement>) => {
+      const originVal = Number($slider[0].value);
+      cy.get(`#toggle-${type}-opacity`).click();
+      expectOpacity(type, originVal === 0 ? 100 : 0);
+      expectToggleButton(type, originVal === 0 ? 100 : 0);
+    });
 }
 
 describe('test: glyph opacity', () => {

--- a/cypress/e2e/resize.cy.ts
+++ b/cypress/e2e/resize.cy.ts
@@ -5,7 +5,9 @@ describe('resize: bounding boxes', () => {
   beforeEach(() => {
     cy.viewport('macbook-13');
     cy.visit('http://localhost:8080/editor.html?manifest=test');
-    cy.get('#mei_output', { timeout: 10000 }).should('be.visible');
+    cy.get('svg.neon-container.active-page', { timeout: 10000 }).should(
+      'be.visible',
+    );
     cy.get('#displayBBox').click();
     cy.get('#selByBBox').click();
 
@@ -15,14 +17,17 @@ describe('resize: bounding boxes', () => {
   const BBOX_ID = '#m-8e6837fc-19d4-42c9-8266-cd54bb6f1dea';
 
   it('oob: bbox should return to original size', () => {
-    cy.get(BBOX_ID)
-      .click()
-      .should('have.class', 'selected');
+    cy.get(BBOX_ID).click().should('have.class', 'selected');
 
     // cy.window() is necessary for d3 dragging
-    cy.window().then(win => {
+    cy.window().then((win) => {
       cy.get('#p-BottomLeft')
-        .trigger('mousedown', { timeout: 100, force: true, which: 1, view: win })
+        .trigger('mousedown', {
+          timeout: 100,
+          force: true,
+          which: 1,
+          view: win,
+        })
         .trigger('mousemove', -100, 0, { force: true })
         .trigger('mouseup', { force: true, view: win });
     });

--- a/cypress/e2e/select.cy.ts
+++ b/cypress/e2e/select.cy.ts
@@ -6,7 +6,9 @@
 beforeEach(() => {
   cy.viewport('macbook-13');
   cy.visit('http://localhost:8080/editor.html?manifest=test');
-  cy.get('#mei_output', { timeout: 10000 }).should('be.visible');
+  cy.get('svg.neon-container.active-page', { timeout: 10000 }).should(
+    'be.visible',
+  );
 });
 
 describe('select: syllable', () => {

--- a/cypress/e2e/settings.cy.ts
+++ b/cypress/e2e/settings.cy.ts
@@ -1,7 +1,9 @@
 beforeEach(() => {
   cy.viewport('macbook-13');
   cy.visit('http://localhost:8080/editor.html?manifest=test');
-  cy.get('#mei_output', { timeout: 10000 }).should('be.visible');
+  cy.get('svg.neon-container.active-page', { timeout: 10000 }).should(
+    'be.visible',
+  );
 });
 
 const LOCALSTORAGE_KEY = 'samples/manifests/test.jsonld';
@@ -9,37 +11,37 @@ const LOCALSTORAGE_KEY = 'samples/manifests/test.jsonld';
 describe('test(settings): highlight', () => {
   it('key: highlight option should change on q/w/e/r/t/y', () => {
     cy.get('body').type('q');
-    cy.window().then(win => {
+    cy.window().then((win) => {
       const settings = JSON.parse(win.localStorage.getItem(LOCALSTORAGE_KEY));
       expect(settings.highlightMode).to.eq('staff');
     });
 
     cy.get('body').type('w');
-    cy.window().then(win => {
+    cy.window().then((win) => {
       const settings = JSON.parse(win.localStorage.getItem(LOCALSTORAGE_KEY));
       expect(settings.highlightMode).to.eq('syllable');
     });
 
     cy.get('body').type('e');
-    cy.window().then(win => {
+    cy.window().then((win) => {
       const settings = JSON.parse(win.localStorage.getItem(LOCALSTORAGE_KEY));
       expect(settings.highlightMode).to.eq('neume');
     });
 
     cy.get('body').type('r');
-    cy.window().then(win => {
+    cy.window().then((win) => {
       const settings = JSON.parse(win.localStorage.getItem(LOCALSTORAGE_KEY));
       expect(settings.highlightMode).to.eq('layerElement');
     });
 
     cy.get('body').type('t');
-    cy.window().then(win => {
+    cy.window().then((win) => {
       const settings = JSON.parse(win.localStorage.getItem(LOCALSTORAGE_KEY));
       expect(settings.highlightMode).to.eq('selection');
     });
 
     cy.get('body').type('y');
-    cy.window().then(win => {
+    cy.window().then((win) => {
       const settings = JSON.parse(win.localStorage.getItem(LOCALSTORAGE_KEY));
       expect(settings.highlightMode).to.eq('none');
     });
@@ -48,14 +50,14 @@ describe('test(settings): highlight', () => {
   it('key: no change if paired with cmd/ctrl', () => {
     // Check cmd/ctrl + r: should refresh the page without a change in highlight option
     cy.get('body').type('{meta}r');
-    cy.window().then(win => {
+    cy.window().then((win) => {
       const settings = JSON.parse(win.localStorage.getItem(LOCALSTORAGE_KEY));
       expect(settings.highlightMode).to.not.eq('layerElement');
     });
 
     // Check cmd/ctrl + q:
     cy.get('body').type('{meta}q');
-    cy.window().then(win => {
+    cy.window().then((win) => {
       const settings = JSON.parse(win.localStorage.getItem(LOCALSTORAGE_KEY));
       expect(settings.highlightMode).to.not.eq('staff');
     });

--- a/cypress/e2e/zoom.cy.ts
+++ b/cypress/e2e/zoom.cy.ts
@@ -10,7 +10,9 @@ describe('test: zoom', () => {
     cy.viewport('macbook-13');
     // Visit the website, and wait until the MEI SVG is visible:
     cy.visit('http://localhost:8080/editor.html?manifest=test');
-    cy.get('#mei_output', { timeout: 10000 }).should('be.visible');
+    cy.get('svg.neon-container.active-page', { timeout: 10000 }).should(
+      'be.visible',
+    );
 
     expectZoom(100);
   });
@@ -34,8 +36,9 @@ describe('test: zoom', () => {
    * Zoom to a percentage value, then run `expectZoom` to check
    * viewbox value and zoom output text value
    */
-  function zoomTo (val: number) {
-    cy.get('#zoomSlider').as('range')
+  function zoomTo(val: number) {
+    cy.get('#zoomSlider')
+      .as('range')
       .trigger('mousedown')
       .invoke('val', val)
       .trigger('mouseup'); // may be "change"
@@ -47,11 +50,11 @@ describe('test: zoom', () => {
    * Function that checks viewbox, slider, and output values to
    * the zoomed in value
    */
-  function expectZoom (val = 100) {
+  function expectZoom(val = 100) {
     // Check whether the SVG has the correct viewbox values
     cy.get('#svg_group')
       .should('have.attr', 'viewBox')
-      .and('eq', ORIGIN_VIEWBOX.map(e => e / (val / 100)).join(' '));
+      .and('eq', ORIGIN_VIEWBOX.map((e) => e / (val / 100)).join(' '));
 
     // Check zoom slider and output values
     cy.get('#zoomSlider').as('range').should('have.value', val);

--- a/src/DivaView.ts
+++ b/src/DivaView.ts
@@ -22,31 +22,41 @@ class DivaView implements ViewInterface {
   /** Time to wait after a page becomes active before loading it. In milliseconds. */
   private loadDelay: number;
   zoomHandler: ZoomHandler;
+  svgId: string;
 
   /**
    * @param manifest - URI/IRI to the IIIF manifest.
    */
-  constructor (neonView: NeonView, Display: DisplayConstructable, manifest: string) {
+  constructor(
+    neonView: NeonView,
+    Display: DisplayConstructable,
+    manifest: string,
+  ) {
     this.neonView = neonView;
     this.updateCallbacks = [];
     this.divaReady = false;
     this.diva = new Diva('container', {
-      objectData: manifest
+      objectData: manifest,
     });
     document.getElementById('container').style.minHeight = '100%';
     this.indexMap = new Map();
     this.diva.disableDragScrollable();
-    this.displayPanel = new Display(this, 'neon-container', 'diva-viewer-canvas');
+    this.displayPanel = new Display(
+      this,
+      'neon-container',
+      'diva-viewer-canvas',
+    );
     this.loadDelay = 500; // in milliseconds
     this.initDivaEvents();
-    (document.querySelector('.diva-inner') as HTMLElement).style.cursor = 'auto';
+    (document.querySelector('.diva-inner') as HTMLElement).style.cursor =
+      'auto';
 
     window.onresize = (): void => {
       const height = window.innerHeight;
       const width = window.innerWidth;
 
       window.setTimeout((): void => {
-        if ((height === window.innerHeight) && (width === window.innerWidth)) {
+        if (height === window.innerHeight && width === window.innerWidth) {
           this.changePage(this.getCurrentPage(), false);
         }
       }, this.loadDelay);
@@ -56,11 +66,27 @@ class DivaView implements ViewInterface {
   /**
    * Set the listeners for certain events internal to diva.js
    */
-  initDivaEvents (): void {
-    Diva.Events.subscribe('ManifestDidLoad', this.parseManifest.bind(this), this.diva.settings.ID);
-    Diva.Events.subscribe('ObjectDidLoad', this.didLoad.bind(this), this.diva.settings.ID);
-    Diva.Events.subscribe('ActivePageDidChange', this.changePage.bind(this), this.diva.settings.ID);
-    Diva.Events.subscribe('ZoomLevelDidChange', this.adjustZoom.bind(this), this.diva.settings.ID);
+  initDivaEvents(): void {
+    Diva.Events.subscribe(
+      'ManifestDidLoad',
+      this.parseManifest.bind(this),
+      this.diva.settings.ID,
+    );
+    Diva.Events.subscribe(
+      'ObjectDidLoad',
+      this.didLoad.bind(this),
+      this.diva.settings.ID,
+    );
+    Diva.Events.subscribe(
+      'ActivePageDidChange',
+      this.changePage.bind(this),
+      this.diva.settings.ID,
+    );
+    Diva.Events.subscribe(
+      'ZoomLevelDidChange',
+      this.adjustZoom.bind(this),
+      this.diva.settings.ID,
+    );
   }
 
   /**
@@ -68,33 +94,38 @@ class DivaView implements ViewInterface {
    * @param pageIndex - The zero-indexed page that is most visible.
    * @param delay - Whether to delay the loading of the page so that neon doesn't lag while scrolling.
    */
-  async changePage (pageIndex: number, delay = true): Promise<void> {
-    function checkAndLoad (page: number): void {
+  async changePage(pageIndex: number, delay = true): Promise<void> {
+    function checkAndLoad(page: number): void {
       if (page === this.getCurrentPage()) {
         const pageURI = this.indexMap.get(page);
-        this.neonView.getPageSVG(pageURI).then((svg: SVGSVGElement) => {
-          this.updateSVG(svg, page);
-          const containerId = 'neon-container-' + page;
-          const container = document.getElementById(containerId);
-          if (container !== null) {
-            container.classList.add('active-page');
-          }
-          this.updateCallbacks.forEach((callback: Function) => callback());
-        }).catch((err: { name: string }) => {
-          if (err.name !== 'not_found' && err.name !== 'missing_mei') {
-            console.error(err);
-          }
-        });
+        this.neonView
+          .getPageSVG(pageURI)
+          .then((svg: SVGSVGElement) => {
+            this.updateSVG(svg, page);
+            const containerId = 'neon-container-' + page;
+            const container = document.getElementById(containerId);
+            if (container !== null) {
+              container.classList.add('active-page');
+            }
+            this.updateCallbacks.forEach((callback: Function) => callback());
+          })
+          .catch((err: { name: string }) => {
+            if (err.name !== 'not_found' && err.name !== 'missing_mei') {
+              console.error(err);
+            }
+          });
       }
     }
 
     const pageIndexes = [pageIndex];
-    Array.from(document.getElementsByClassName('active-page')).forEach(elem => {
-      elem.classList.remove('active-page');
-    });
+    Array.from(document.getElementsByClassName('active-page')).forEach(
+      (elem) => {
+        elem.classList.remove('active-page');
+      },
+    );
     for (const page of pageIndexes) {
       if (delay) {
-        window.setTimeout(checkAndLoad.bind(this), (this.loadDelay), page);
+        window.setTimeout(checkAndLoad.bind(this), this.loadDelay, page);
       } else {
         checkAndLoad.bind(this)(page);
       }
@@ -104,38 +135,42 @@ class DivaView implements ViewInterface {
   /**
    * @returns Active zero-indexed page in the diva.js viewer.
    */
-  getCurrentPage (): number {
+  getCurrentPage(): number {
     return this.diva.getActivePageIndex();
   }
 
   /**
    * @returns The active page URI in the diva.js viewer.
    */
-  getCurrentPageURI (): string {
+  getCurrentPageURI(): string {
     return this.indexMap.get(this.getCurrentPage());
   }
 
   /**
    * Adjust the rendered SVG(s) to be the correct size after zooming.
    */
-  adjustZoom (): void {
-    (new Promise((resolve): void => {
-      Array.from(document.getElementsByClassName('neon-container'))
-        .forEach((elem: HTMLElement) => { elem.style.display = 'none'; });
+  adjustZoom(): void {
+    new Promise((resolve): void => {
+      Array.from(document.getElementsByClassName('neon-container')).forEach(
+        (elem: HTMLElement) => {
+          elem.style.display = 'none';
+        },
+      );
       setTimeout(resolve, this.diva.settings.zoomDuration + 100);
-    })).then(() => {
+    }).then(() => {
       this.changePage(this.diva.getActivePageIndex(), true);
-      Array.from(document.getElementsByClassName('neon-container'))
-        .forEach((elem: HTMLElement) => {
+      Array.from(document.getElementsByClassName('neon-container')).forEach(
+        (elem: HTMLElement) => {
           const svg = elem.firstChild as SVGSVGElement;
           const pageNo = parseInt(elem.id.match(/\d+/)[0]);
           this.updateSVG(svg, pageNo);
           elem.style.display = '';
-        });
+        },
+      );
     });
   }
 
-  onSVGLoad (): void {
+  onSVGLoad(): void {
     this.setViewEventHandlers();
   }
 
@@ -144,14 +179,18 @@ class DivaView implements ViewInterface {
    * @param svg - The SVG of the page to update to.
    * @param pageNo - The zero-indexed page number.
    */
-  updateSVG (svg: SVGSVGElement, pageNo: number): void {
+  updateSVG(svg: SVGSVGElement, pageNo: number): void {
     const inner = document.getElementById('diva-1-inner');
     const dimensions = this.diva.getPageDimensionsAtCurrentZoomLevel(pageNo);
-    const offset = this.diva.settings.viewHandler._viewerCore.getPageRegion(pageNo, {
-      includePadding: true,
-      incorporateViewport: true
-    });
-    const marginLeft = window.getComputedStyle(inner, null)
+    const offset = this.diva.settings.viewHandler._viewerCore.getPageRegion(
+      pageNo,
+      {
+        includePadding: true,
+        incorporateViewport: true,
+      },
+    );
+    const marginLeft = window
+      .getComputedStyle(inner, null)
       .getPropertyValue('margin-left');
 
     const containerId = 'neon-container-' + pageNo.toString();
@@ -179,7 +218,7 @@ class DivaView implements ViewInterface {
   /**
    * Function called when diva.js finishes loading.
    */
-  didLoad (): void {
+  didLoad(): void {
     this.divaReady = true;
     this.displayPanel.setDisplayListeners();
     document.getElementById('loading').style.display = 'none';
@@ -189,7 +228,7 @@ class DivaView implements ViewInterface {
    * Add a callback function that will be run whenever an SVG is updated.
    * @param cb - The callback function.
    */
-  addUpdateCallback (cb: () => void): void {
+  addUpdateCallback(cb: () => void): void {
     this.updateCallbacks.push(cb);
   }
 
@@ -197,7 +236,7 @@ class DivaView implements ViewInterface {
    * Remove a callback function previously added to the list of functions to call.
    * @param cb - The callback function.
    */
-  removeUpdateCallback (cb: () => void): void {
+  removeUpdateCallback(cb: () => void): void {
     const index = this.updateCallbacks.findIndex((elem) => {
       return elem === cb;
     });
@@ -209,26 +248,32 @@ class DivaView implements ViewInterface {
   /**
    * Set listeners on the body element for global events.
    */
-  setViewEventHandlers (): void {
+  setViewEventHandlers(): void {
     document.body.addEventListener('keydown', (evt) => {
       switch (evt.key) {
         case 'h':
-          for (const container of document.getElementsByClassName('neon-container') as HTMLCollectionOf<HTMLElement>) {
+          for (const container of document.getElementsByClassName(
+            'neon-container',
+          ) as HTMLCollectionOf<HTMLElement>) {
             container.style.visibility = 'hidden';
           }
           break;
-        default: break;
+        default:
+          break;
       }
     });
 
     document.body.addEventListener('keyup', (evt) => {
       switch (evt.key) {
         case 'h':
-          for (const container of document.getElementsByClassName('neon-container') as HTMLCollectionOf<HTMLElement>) {
+          for (const container of document.getElementsByClassName(
+            'neon-container',
+          ) as HTMLCollectionOf<HTMLElement>) {
             container.style.visibility = '';
           }
           break;
-        default: break;
+        default:
+          break;
       }
     });
   }
@@ -237,7 +282,7 @@ class DivaView implements ViewInterface {
    * Use the IIIF manifest to create a map between IIIF canvases and page indexes.
    * @param manifest - The IIIF manifest object.
    */
-  parseManifest (manifest: { sequences: { canvases: object[] }[] }): void {
+  parseManifest(manifest: { sequences: { canvases: object[] }[] }): void {
     this.indexMap.clear();
     for (const sequence of manifest.sequences) {
       for (const canvas of sequence.canvases) {
@@ -249,7 +294,7 @@ class DivaView implements ViewInterface {
   /**
    * @returns The name of the active page/canvas combined with the manuscript name.
    */
-  getPageName (): string {
+  getPageName(): string {
     const manuscriptName = this.diva.settings.manifest.itemTitle;
     const pageName = this.diva.settings.manifest.pages[this.getCurrentPage()].l;
     return manuscriptName + ' \u2014 ' + pageName;

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -4,7 +4,12 @@ import ZoomHandler from './SingleView/Zoom';
 import { ModalWindowView } from './utils/ModalWindow';
 
 export interface DisplayConstructable {
-  new (a: ViewInterface, b: string, c: string, d?: ZoomHandler): DisplayInterface;
+  new (
+    a: ViewInterface,
+    b: string,
+    c: string,
+    d?: ZoomHandler,
+  ): DisplayInterface;
 }
 
 export interface DisplayInterface {
@@ -12,9 +17,9 @@ export interface DisplayInterface {
   meiClass: string;
   background: string;
   zoomHandler: ZoomHandler;
-  setDisplayListeners (): void;
-  updateVisualization (): void;
-  loadSettings (): void;
+  setDisplayListeners(): void;
+  updateVisualization(): void;
+  loadSettings(): void;
 }
 
 export interface ViewConstructable {
@@ -23,12 +28,13 @@ export interface ViewConstructable {
 
 export interface ViewInterface {
   zoomHandler: ZoomHandler;
-  changePage (pageIndex: number, delay: boolean): Promise<void>;
+  changePage(pageIndex: number, delay: boolean): Promise<void>;
   addUpdateCallback(a: Function);
-  getCurrentPage (): number;
-  getCurrentPageURI (): string;
-  getPageName (): string;
-  onSVGLoad? (): void;
+  getCurrentPage(): number;
+  getCurrentPageURI(): string;
+  getPageName(): string;
+  onSVGLoad?(): void;
+  svgId: string;
 }
 
 export interface NeumeEditConstructable {
@@ -36,9 +42,9 @@ export interface NeumeEditConstructable {
 }
 
 export interface NeumeEditInterface {
-  initEditMode (): void;
-  getUserMode (): UserType;
-  setSelectListeners (): void;
+  initEditMode(): void;
+  getUserMode(): UserType;
+  setSelectListeners(): void;
 }
 
 export interface TextEditConstructable {
@@ -46,9 +52,9 @@ export interface TextEditConstructable {
 }
 
 export interface TextEditInterface {
-  initTextEdit (): void;
-  initSelectByBBoxButton (): void;
-  initBBoxCircleSlider (): void;
+  initTextEdit(): void;
+  initSelectByBBoxButton(): void;
+  initBBoxCircleSlider(): void;
 }
 
 export interface ModalWindowInterface {
@@ -62,8 +68,8 @@ export interface TextViewConstructable {
 }
 
 export interface TextViewInterface {
-  updateBBoxVisibility (): void;
-  getSylText (): string;
+  updateBBoxVisibility(): void;
+  getSylText(): string;
 }
 
 export interface InfoConstructable {
@@ -71,15 +77,15 @@ export interface InfoConstructable {
 }
 
 export interface InfoInterface {
-  getContour (ncs: Iterable<SVGGraphicsElement>): Promise<string>;
-  getPitches (ncs: Iterable<SVGGraphicsElement>): Promise<string>;
-  pitchNameToNum (pname: string): number;
-  getContourByValue (value: string): string;
-  updateInfoModule (body: string): void;
-  infoListeners (): void;
-  stopListeners (): void;
-  resetInfoListeners (): void;
-  updateInfo (evt: MouseEvent): Promise<void>;
+  getContour(ncs: Iterable<SVGGraphicsElement>): Promise<string>;
+  getPitches(ncs: Iterable<SVGGraphicsElement>): Promise<string>;
+  pitchNameToNum(pname: string): number;
+  getContourByValue(value: string): string;
+  updateInfoModule(body: string): void;
+  infoListeners(): void;
+  stopListeners(): void;
+  resetInfoListeners(): void;
+  updateInfo(evt: MouseEvent): Promise<void>;
 }
 
 export interface NeonViewParams {

--- a/src/SingleView/SingleView.ts
+++ b/src/SingleView/SingleView.ts
@@ -1,4 +1,8 @@
-import { updateHighlight, setGlyphOpacityFromSlider, setBgOpacityFromSlider } from '../DisplayPanel/DisplayControls';
+import {
+  updateHighlight,
+  setGlyphOpacityFromSlider,
+  setBgOpacityFromSlider,
+} from '../DisplayPanel/DisplayControls';
 import NeonView from '../NeonView';
 import DisplayPanel from '../DisplayPanel/DisplayPanel';
 import ZoomHandler from './Zoom';
@@ -17,6 +21,7 @@ class SingleView implements ViewInterface {
   private group: SVGSVGElement;
   private bg: SVGImageElement;
   private svg: SVGSVGElement;
+  svgId: string; // Change to readonly
   zoomHandler: ZoomHandler;
   private displayPanel: DisplayPanel;
   readonly pageURI: string;
@@ -24,7 +29,7 @@ class SingleView implements ViewInterface {
    * Constructor for SingleView.
    * @param image - The URI to the background image for the page.
    */
-  constructor (neonView: NeonView, panel: DisplayConstructable, image: string) {
+  constructor(neonView: NeonView, panel: DisplayConstructable, image: string) {
     this.neonView = neonView;
     this.container = document.getElementById('container');
     this.updateCallbacks = new Array(0);
@@ -41,54 +46,69 @@ class SingleView implements ViewInterface {
     this.bg.setAttribute('y', '0');
 
     const reader = new FileReader();
-    fetch(image).then(result => {
-      if (result.ok) {
-        reader.addEventListener('load', () => {
-          this.bg.setAttributeNS('http://www.w3.org/1999/xlink', 'href', reader.result.toString());
-          const bbox = this.bg.getBBox();
-          if (!this.group.hasAttribute('viewBox')) {
-            /*
+    fetch(image)
+      .then((result) => {
+        if (result.ok) {
+          reader.addEventListener('load', () => {
+            this.bg.setAttributeNS(
+              'http://www.w3.org/1999/xlink',
+              'href',
+              reader.result.toString(),
+            );
+            const bbox = this.bg.getBBox();
+            if (!this.group.hasAttribute('viewBox')) {
+              /*
               If the SVG does not have a viewBox, load the previous viewBox
               value from localStorage. If none has been stored (viewBox is null),
               set it to the default value of the width and height of the background image
-              
+
               Note: an SVG's viewBox gives the "box" that the user can see the SVG through.
               The user may be zoomed into a very specific section of the SVG, in which case the
               viewBox should give coordinates of that specific box.
 
               See more: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox
             */
-            let { viewBox } = getSettings();
-            if (!viewBox)
-              viewBox = '0 0 ' + bbox.width.toString() + ' ' + bbox.height.toString();
+              let { viewBox } = getSettings();
+              if (!viewBox)
+                viewBox =
+                  '0 0 ' + bbox.width.toString() + ' ' + bbox.height.toString();
 
-            this.group.setAttribute('viewBox', viewBox);
-          }
-        });
-        return result.blob();
-      }
-    }).then(blob => {
-      reader.readAsDataURL(blob);
-    });
+              this.group.setAttribute('viewBox', viewBox);
+            }
+          });
+          return result.blob();
+        }
+      })
+      .then((blob) => {
+        reader.readAsDataURL(blob);
+      });
 
     // It is better named svg, to avoid confusion with the actual MEI file.
-    this.svg = document.createElementNS('http://www.w3.org/svg', 'svg') as SVGSVGElement;
-    this.svg.id = 'mei_output';
+    this.svg = document.createElementNS(
+      'http://www.w3.org/svg',
+      'svg',
+    ) as SVGSVGElement;
     this.svg.classList.add('neon-container', 'active-page');
+    this.svgId = this.svg.id;
 
     this.group.appendChild(this.bg);
     this.group.appendChild(this.svg);
     this.container.appendChild(this.group);
 
     this.zoomHandler = new ZoomHandler();
-    this.displayPanel = new panel(this, 'neon-container', 'background', this.zoomHandler);
+    this.displayPanel = new panel(
+      this,
+      'neon-container',
+      'background',
+      this.zoomHandler,
+    );
 
     this.pageURI = image;
 
     document.getElementById('loading').style.display = 'none';
   }
 
-  onSVGLoad (): void {
+  onSVGLoad(): void {
     this.setViewEventHandlers();
     this.displayPanel.setDisplayListeners();
   }
@@ -97,11 +117,11 @@ class SingleView implements ViewInterface {
    * Update the SVG being displayed.
    * @param svg - New rendered SVG to use.
    */
-  updateSVG (svg: SVGSVGElement): void {
+  updateSVG(svg: SVGSVGElement): void {
     this.group.replaceChild(svg, this.svg);
     this.svg = svg;
-    this.svg.id = 'mei_output';
     this.svg.classList.add('neon-container', 'active-page');
+    this.svgId = this.svg.id;
     const height = parseInt(this.svg.getAttribute('height'));
     const width = parseInt(this.svg.getAttribute('width'));
 
@@ -111,19 +131,18 @@ class SingleView implements ViewInterface {
     const { viewBox } = getSettings();
     if (!viewBox)
       this.group.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
-    else
-      this.group.setAttribute('viewBox', viewBox);
+    else this.group.setAttribute('viewBox', viewBox);
 
     updateHighlight();
     this.resetTransformations();
-    this.updateCallbacks.forEach(callback => callback());
+    this.updateCallbacks.forEach((callback) => callback());
   }
 
   /**
    * Change to a certain page
    * Since there is only one page, this is essentially a wrapper for updateSVG
    */
-  async changePage (_page: number, _delay: boolean): Promise<void> {
+  async changePage(_page: number, _delay: boolean): Promise<void> {
     const svg = await this.neonView.getPageSVG(this.getCurrentPageURI());
     this.updateSVG(svg);
   }
@@ -132,7 +151,7 @@ class SingleView implements ViewInterface {
    * Add a callback to the list of those be called when the page updates.
    * @param cb - The callback function.
    */
-  addUpdateCallback (cb: () => void): void {
+  addUpdateCallback(cb: () => void): void {
     this.updateCallbacks.push(cb);
   }
 
@@ -140,7 +159,7 @@ class SingleView implements ViewInterface {
    * Remove a callback from the list of callbacks if it is part of the list.
    * @param cb - The callback function.
    */
-  removeUpdateCallback (cb: () => void): void {
+  removeUpdateCallback(cb: () => void): void {
     const index = this.updateCallbacks.findIndex((elem) => {
       return elem === cb;
     });
@@ -152,7 +171,7 @@ class SingleView implements ViewInterface {
   /**
    * Reset the transformations that have been applied to the SVG upon update.
    */
-  resetTransformations (): void {
+  resetTransformations(): void {
     this.displayPanel.zoomHandler.restoreTransformation();
     setGlyphOpacityFromSlider();
     setBgOpacityFromSlider();
@@ -161,34 +180,49 @@ class SingleView implements ViewInterface {
   /**
    * @returns The zero-indexed number of the current page. This will always be zero.
    */
-  getCurrentPage (): number {
+  getCurrentPage(): number {
     return 0;
   }
 
   /**
    * @returns The URI of the page.
    */
-  getCurrentPageURI (): string {
+  getCurrentPageURI(): string {
     return this.pageURI;
   }
 
   /**
    * Set event handlers for the view and display panel.
    */
-  setViewEventHandlers (): void {
+  setViewEventHandlers(): void {
     document.body.addEventListener('keydown', (evt) => {
       switch (evt.key) {
         case 'Shift':
           d3.select('#svg_group').on('.drag', null);
           d3.select('#svg_group').call(
-            d3.drag().on('start', this.displayPanel.zoomHandler.startDrag.bind(this.displayPanel.zoomHandler))
-              .on('drag', this.displayPanel.zoomHandler.dragging.bind(this.displayPanel.zoomHandler))
+            d3
+              .drag()
+              .on(
+                'start',
+                this.displayPanel.zoomHandler.startDrag.bind(
+                  this.displayPanel.zoomHandler,
+                ),
+              )
+              .on(
+                'drag',
+                this.displayPanel.zoomHandler.dragging.bind(
+                  this.displayPanel.zoomHandler,
+                ),
+              ),
           );
           break;
         case 'h':
-          document.getElementById('mei_output').setAttribute('visibility', 'hidden');
+          document
+            .getElementById(this.svgId)
+            .setAttribute('visibility', 'hidden');
           break;
-        default: break;
+        default:
+          break;
       }
     });
     document.body.addEventListener('keyup', (evt) => {
@@ -200,22 +234,36 @@ class SingleView implements ViewInterface {
           }
           break;
         case 'h':
-          document.getElementById('mei_output').setAttribute('visibility', 'visible');
+          document
+            .getElementById(this.svgId)
+            .setAttribute('visibility', 'visible');
           break;
-        default: break;
+        default:
+          break;
       }
     });
 
     d3.select('#container').on('touchstart', () => {
       if (d3.event.touches.length === 2) {
         this.displayPanel.zoomHandler.startDrag();
-        d3.select('#container').on('touchmove', this.displayPanel.zoomHandler.dragging.bind(this.displayPanel.zoomHandler));
+        d3.select('#container').on(
+          'touchmove',
+          this.displayPanel.zoomHandler.dragging.bind(
+            this.displayPanel.zoomHandler,
+          ),
+        );
         d3.select('#container').on('touchend', () => {
           d3.select('#container').on('touchmove', null);
         });
       }
     });
-    d3.select('#container').on('wheel', this.displayPanel.zoomHandler.scrollZoom.bind(this.displayPanel.zoomHandler), false);
+    d3.select('#container').on(
+      'wheel',
+      this.displayPanel.zoomHandler.scrollZoom.bind(
+        this.displayPanel.zoomHandler,
+      ),
+      false,
+    );
     // Update height of container based on window
     window.onresize = (): void => {
       const newHeight = window.innerHeight;
@@ -229,7 +277,7 @@ class SingleView implements ViewInterface {
   /**
    * @returns A human readable name for the page. Used for downloads.
    */
-  getPageName (): string {
+  getPageName(): string {
     return this.neonView.name;
   }
 }

--- a/src/TextEditMode.ts
+++ b/src/TextEditMode.ts
@@ -160,7 +160,9 @@ export default class TextEditMode implements TextEditInterface {
         );
         setSelectHelperObjects(this.neonView, this.dragHandler);
         if (this.neonView.view.constructor.name === 'SingleView') {
-          clickSelect('#mei_output, #mei_output rect');
+          clickSelect(
+            `#${this.neonView.view.svgId}, #${this.neonView.view.svgId} rect`,
+          );
           dragSelect('#svg_group');
         } else {
           clickSelect(

--- a/src/utils/Color.ts
+++ b/src/utils/Color.ts
@@ -28,12 +28,7 @@ export function unhighlight(staff?: SVGGElement): void {
   }
   children.forEach((elem) => {
     if (
-      elem.tagName === 'path' &&
-      !elem.closest('.staff').classList.contains('selected')
-    ) {
-      (elem as SVGPathElement).style.stroke = '#000000';
-    } else if (
-      elem.classList.contains('divLine') &&
+      (elem.tagName === 'path' || elem.classList.contains('divLine')) &&
       !elem.closest('.staff').classList.contains('selected')
     ) {
       (elem as SVGPathElement).style.color = '#000000';
@@ -123,7 +118,7 @@ export function highlight(staff: SVGGElement, color: string): void {
   for (let i = 0; i < children.length; i++) {
     const child = children[i];
     if (child.tagName === 'path') {
-      (child as SVGPathElement).style.stroke = color;
+      (child as SVGPathElement).style.color = color;
     } else if (child.classList.contains('divLine')) {
       (child as SVGPathElement).style.color = color;
       child.setAttribute('stroke-width', '30px');


### PR DESCRIPTION
- To make svg style effective, use default svg id from verovio instead of `#mei_output`
- Introduce `SingleView.svgId` and `DivaView.svgId`
- Use color to set stroke color for staff
- Combine conditions for staff and divLine highlight color

refs: #1297