### PR TITLE
fix: track MEI version and fetch schema on version change

### DIFF
--- a/src/Validation.ts
+++ b/src/Validation.ts
@@ -2,6 +2,7 @@ import NeonView from './NeonView';
 import { ModalWindowView } from './utils/ModalWindow';
 
 let worker: Worker,
+  currentVersion: string, // To keep track of the current version of the MEI file
   schema: string,
   versionField: HTMLSpanElement,
   statusField: HTMLSpanElement;
@@ -102,7 +103,8 @@ export async function sendForValidation(meiData: string): Promise<void> {
   versionField.style.color = 'gray';
   updateVersionUI(meiVersion);
 
-  if (schema === undefined) {
+  if (schema === undefined || meiVersion !== currentVersion) {
+    currentVersion = meiVersion;
     schema = await fetchSchema(meiVersion);
   }
   statusField.textContent = 'checking...';


### PR DESCRIPTION
- This is because current Verovio will always output file in MEI 5.1 no matter which version the input file is in.
- Introduced `currentVersion`
- Fetched new schema on version change

refs: #1302