### PR TITLE
fix: fall back to `dev` schema for dev MEI versions

### DIFF
--- a/src/Validation.ts
+++ b/src/Validation.ts
@@ -8,14 +8,24 @@ let worker: Worker,
   statusField: HTMLSpanElement;
 
 async function fetchSchema(version: string): Promise<string> {
-  const baseUrl = 'https://raw.githubusercontent.com/music-encoding/schema/';
-  const schemaUrl = `${baseUrl}/main/${version}/mei-all.rng`;
-  const response = await fetch(schemaUrl);
+  const baseUrl = 'https://raw.githubusercontent.com/music-encoding/schema/main/';
+
+  const tryFetch = (folder: string): Promise<Response> => {
+    return fetch(`${baseUrl}${folder}/mei-all.rng`);
+  };
+
+  let response = await tryFetch(version);
+
+  if (!response.ok && version.includes('dev')) {
+    response = await tryFetch('dev');
+  }
+
   if (!response.ok) {
     statusField.textContent = 'Unknown MEI Version';
     statusField.style.color = 'red';
     throw new Error(`Failed to fetch schema for MEI version ${version}`);
   }
+
   return await response.text();
 }
 


### PR DESCRIPTION
Verovio was updated and now defaults to outputting `6.0-dev`. When Neon tries to fetch the corresponding schema for validation, it constructs the URL using the mei version attribute. However, the music-encoding schema repository does not have a `6.0-dev` folder. The dev schema lives under `dev/`. This causes the fetch to 404, and Neon surfaces "Unknown MEI Version" to the user.

Since there is no way to set the version Verovio outputs, the fix lives on the schema-fetching side in Neon. `fetchSchema` now tries the exact mei version value first. If that fetch fails and the version contains `dev`, it retries with `dev` as the schema folder. This preserves forward compatibility: if a future dev version gets its own dedicated folder on the schema repo, it will be used automatically; only versions without a matching folder fall back to dev.

refs: #1356