### PR TITLE
Remember the last selected upload notation type

### DIFF
--- a/src/Dashboard/UploadArea.ts
+++ b/src/Dashboard/UploadArea.ts
@@ -7,6 +7,10 @@ import {
 } from './UploadTools';
 import { updateDashboard } from './Dashboard';
 import { IFolder } from './FileSystem';
+import {
+  getUploadNotationType,
+  setUploadNotationType,
+} from './UploadNotationType';
 
 async function handleUploadUpdate(
   modalWindow: ModalWindow,
@@ -60,6 +64,16 @@ export function InitUploadArea(currentFolder: IFolder): void {
 
   const pairButton = document.querySelector('#make_pair');
   const uploadButton = document.querySelector('#upload_button');
+  const notationTypeInputs: NodeListOf<HTMLInputElement> =
+    document.querySelectorAll('input[name="upload_notation_type"]');
+  const savedNotationType = getUploadNotationType();
+
+  notationTypeInputs.forEach((input) => {
+    input.checked = input.value === savedNotationType;
+    input.addEventListener('change', () => {
+      if (input.checked) setUploadNotationType(input.value);
+    });
+  });
 
   pairButton.addEventListener('click', handleMakePair);
   uploadButton.addEventListener('click', () =>

--- a/src/Dashboard/UploadNotationType.ts
+++ b/src/Dashboard/UploadNotationType.ts
@@ -1,0 +1,16 @@
+export type UploadNotationType = 'square' | 'hufnagel';
+
+const STORAGE_KEY = 'neon-upload-notation-type';
+const DEFAULT_NOTATION_TYPE: UploadNotationType = 'square';
+
+export function getUploadNotationType(): UploadNotationType {
+  const storedNotationType = window.localStorage.getItem(STORAGE_KEY);
+  return storedNotationType === 'hufnagel' || storedNotationType === 'square'
+    ? storedNotationType
+    : DEFAULT_NOTATION_TYPE;
+}
+
+export function setUploadNotationType(notationType: string): void {
+  if (notationType !== 'hufnagel' && notationType !== 'square') return;
+  window.localStorage.setItem(STORAGE_KEY, notationType);
+}

--- a/test/UploadNotationType.test.ts
+++ b/test/UploadNotationType.test.ts
@@ -1,0 +1,27 @@
+import {
+  getUploadNotationType,
+  setUploadNotationType,
+} from '../src/Dashboard/UploadNotationType';
+
+describe('upload notation type preference', () => {
+  beforeEach(() => window.localStorage.clear());
+
+  test('defaults to square', () => {
+    expect(getUploadNotationType()).toBe('square');
+  });
+
+  test('remembers the selected notation type', () => {
+    setUploadNotationType('hufnagel');
+    expect(getUploadNotationType()).toBe('hufnagel');
+
+    setUploadNotationType('square');
+    expect(getUploadNotationType()).toBe('square');
+  });
+
+  test('ignores unsupported notation types', () => {
+    setUploadNotationType('hufnagel');
+    setUploadNotationType('unsupported');
+
+    expect(getUploadNotationType()).toBe('hufnagel');
+  });
+});


### PR DESCRIPTION
## Summary

Remember the notation type selected in the upload modal and restore it the next time the modal is opened.

## Testing

- Tested both Square and Hufnagel selections locally.
- Confirmed that the last selection is restored after closing and reopening the upload modal.
- Added unit tests for the stored preference.

Closes #1371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a preference for selecting the upload notation format.
  * The selected format is remembered and restored when returning to the upload area.
  * Unsupported preference values are safely ignored, using the standard format instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->